### PR TITLE
채팅 메시지 송수신/브로드캐스트 흐름 개선 및 전역 오류 처리 통합

### DIFF
--- a/docs/feature-specs/chat-message-send-and-broadcast.adoc
+++ b/docs/feature-specs/chat-message-send-and-broadcast.adoc
@@ -1,0 +1,303 @@
+= Chat Message Send & Broadcast Technical Specification
+:toc:
+:toclevels: 4
+:sectnums:
+:source-highlighter: highlight.js
+
+== 1. 문서 목적
+
+이 문서는 채팅 시스템의 *메시지 전송(send)* 및 *브로드캐스트(broadcast)* 기능을 기술 명세 관점에서 설명한다.
+
+* 포함 범위
+** 메시지 전송 STOMP 진입점
+** 퍼사드 오케스트레이션(검증/저장/메타 업데이트/브로드캐스트)
+** 수신자 사용자 전용 큐 전송
+** 룸 브로드캐스트 릴레이
+** 멤버 조회/미읽음 카운트 증가
+** 표시 닉네임(display nickname) 결정
+
+* 제외 범위
+** GlobalExceptionHandler 및 도메인 예외 상세 정책
+
+== 2. 기능 책임(What)
+
+=== 3.1 채팅 메시지 기능의 책임
+
+. 발신 요청을 수신한다.
+. 발신자의 자격/상태를 검증한다.
+. 메시지를 영속화한다.
+. 채팅방/채팅목록 메타를 갱신한다.
+. 수신자별 payload(닉네임, mine)를 계산한다.
+. 사용자 전용 큐로 실시간 전달한다.
+
+== 3. 입력/출력 데이터 계약
+
+=== 4.1 입력 DTO: `ChatSendRequest`
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/dto/request/ChatSendRequest.java[lines=1..20]
+----
+
+필드 의미:
+
+* `roomId`: 메시지를 보낼 채팅방 식별자
+* `messageType`: 메시지 타입(TEXT/IMAGE/FILE 등)
+* `text`: 본문
+
+=== 4.2 출력 DTO: `ChatMessageResponse` / `ChatMessageSenderResponse`
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/dto/response/ChatMessageResponse.java[lines=1..40]
+----
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/dto/response/ChatMessageSenderResponse.java[lines=1..40]
+----
+
+특이사항:
+
+* `sender.senderNickname`은 수신자 관점으로 계산된 표시 닉네임
+* `sender.mine`은 "현재 수신자 기준 본인 메시지 여부"
+
+== 4. 런타임 시퀀스(How)
+
+=== 5.1 STOMP 진입점
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/controller/ChatMessageController.java[lines=22..56]
+----
+
+* `@MessageMapping("chat/message")`: 전송 요청 진입
+* `@MessageMapping("chat/broadcast")`: 릴레이 요청 진입
+
+=== 5.2 퍼사드 오케스트레이션
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/service/impl/ChatMessageFacadeServiceImpl.java[lines=25..160]
+----
+
+핵심 단계:
+
+. room/member 식별
+. `validateSendPermission`으로 권한/차단 검증
+. `chatMessageService.createChatMessage`로 저장
+. `chatRoomService.updateLastMessageInfo`로 방 메타 갱신
+. `chatListService.increaseUnreadCount`로 미읽음 증가
+. `chatListService.getRoomMemberUserIds`로 대상 조회
+. `createResponseForReceiver`로 수신자별 payload 작성
+. `chatMessageBroadCaster.broadcastMessage` 전송
+
+=== 5.3 브로드캐스트 계층
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/websocket/broadcaster/ChatMessageBroadCaster.java[lines=1..40]
+----
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/websocket/broadcaster/impl/ChatMessageBroadCasterImpl.java[lines=11..70]
+----
+
+설명:
+
+* `broadcastMessage`: `convertAndSendToUser` 기반 사용자 전용 destination 전송
+* `relayRoomBroadcast`: 룸 구독 destination으로 릴레이
+
+=== 5.4 채팅목록 계층
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatlist/service/ChatListService.java[lines=1..60]
+----
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatlist/service/impl/ChatListServiceImpl.java[lines=24..120]
+----
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatlist/repository/ChatListRepository.java[lines=11..70]
+----
+
+역할:
+
+* `ensureMembership`: room-user 멤버십 upsert
+* `increaseUnreadCount`: 발신자 제외 unread +1
+* `findUserIdsByRoomId`: 방 멤버 userId 목록 조회
+
+=== 5.5 표시 닉네임 계산
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/user/service/impl/UserDisplayNameServiceImpl.java[lines=20..70]
+----
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/friend/repository/FriendRepository.java[lines=1..40]
+----
+
+우선순위:
+
+. 수신자가 발신자에게 지정한 friend custom nickname
+. 발신자의 기본 nickname
+
+== 5. 메서드별 상세 명세
+
+=== 6.1 `ChatMessageController.sendMessage`
+
+* 목적: STOMP 수신 후 애플리케이션 서비스 호출
+* 입력: `ChatSendRequest`, `Authentication`
+* 성공 시: 퍼사드 완료 후 반환(void)
+* 실패 시: principal 캐스팅/도메인 검증 예외 전파
+
+=== 6.2 `ChatMessageFacadeServiceImpl.sendMessage`
+
+* 목적: 전송 유스케이스 전체 오케스트레이션
+* 입력: 요청 DTO, 발신자 ID
+* 성공 시: 저장 + 메타 업데이트 + 수신자별 전송
+* 실패 시: 권한/차단/미존재 등 검증 실패 예외 발생
+
+=== 6.3 `validateSendPermission`
+
+* 목적: 발신자 권한 검증 및 차단 관계 확인
+* 성공 시: 후속 저장 단계 진입 허용
+* 실패 시: 검증 예외 발생
+
+=== 6.4 `updateRoomAndChatListOnSend`
+
+* 목적: 채팅방의 마지막 메시지 정보 동기화
+* 성공 시: 최신 메시지 메타 반영
+
+=== 6.5 `createResponseForReceiver`
+
+* 목적: 수신자별 payload 구성
+* 핵심: `displayNickname`, `mine` 계산
+* 성공 시: `ChatMessageResponse` 반환
+
+=== 6.6 `ChatMessageBroadCasterImpl.broadcastMessage`
+
+* 목적: 특정 사용자 큐로 이벤트 전달
+* 입력: 수신자 ID, 응답 DTO
+* 성공 기준: 메시지 템플릿 호출이 예외 없이 종료
+
+=== 6.7 `ChatMessageBroadCasterImpl.relayRoomBroadcast`
+
+* 목적: 룸 구독 경로로 이벤트 재발행
+* 입력: 응답 DTO
+
+=== 6.8 `ChatListRepository` 쿼리 메서드
+
+* `upsertMembership`: 멤버십 보장
+* `increaseUnreadCount`: 발신자 제외 증가
+* `findUserIdsByRoomId`: 대상 사용자 목록 조회
+
+=== 6.9 `UserDisplayNameServiceImpl.resolveDisplayName`
+
+* 목적: 수신자 관점 표시명 결정
+* 입력: senderId, receiverId
+* 성공 시: Optional<String> 표시명 반환
+
+== 6. 유효성 검증 및 성공 조건
+
+=== 7.1 유효성 검증 포인트
+
+* 멤버십 검증: room-user 연관 유효성 확인
+* 차단 검증: 차단 관계면 전송 차단
+* 전송 요청 기본 값: roomId/type/text는 상위 계층에서 유효 값 가정
+
+=== 7.2 성공 판단
+
+성공은 아래 단계를 모두 완료했을 때로 본다.
+
+. 메시지 영속화 성공
+. 채팅방 마지막 메시지 메타 갱신 성공
+. 미읽음 카운트 증가 성공
+. 수신자별 브로드캐스트 호출 완료
+
+== 7. 트랜잭션 경계 설명
+
+[source,java]
+----
+include::../../src/main/java/com/chat_server/chatmessage/service/impl/ChatMessageFacadeServiceImpl.java[lines=25..35]
+----
+
+현재 구현은 퍼사드 클래스 레벨 `@Transactional` 경계 내에서 저장/갱신/브로드캐스트 호출이 이뤄진다.
+
+장점:
+
+* 실패 시 저장 로직 롤백 정책을 단일 경계에서 관리하기 쉽다.
+
+주의점:
+
+* 실시간 전송(I/O)과 DB 트랜잭션 결합으로 트랜잭션 체류 시간이 길어질 수 있다.
+* 클라이언트 전달 보장은 별개이며, 메시징과 DB의 완전 원자성은 별도 패턴(Outbox 등) 필요.
+
+== 8. 쿼리 선택 배경: QueryDSL 대신 JPQL/Native 사용
+
+=== 9.1 왜 QueryDSL이 아닌가
+
+이 기능에서 필요한 쿼리는 아래와 같이 단순/명확하다.
+
+* 멤버십 upsert (DB native 문법 활용)
+* unread count 일괄 증가(update)
+* 채팅방 멤버 user_id 단순 projection
+* 친구 custom nickname 단순 조건 조회
+
+즉, 동적 조건 조합이 복잡하지 않아 QueryDSL의 이점이 상대적으로 작고,
+반대로 upsert 같은 DB 의존 구문은 native query가 더 직관적이다.
+
+=== 9.2 쿼리별 설명
+
+`upsertMembership`:
+
+* SQL: `INSERT ... ON DUPLICATE KEY UPDATE`
+* 목적: 중복 없는 멤버십 보장
+
+`increaseUnreadCount`:
+
+* SQL: `UPDATE chat_list SET unread_count = unread_count + 1 WHERE chat_room_id = :roomId AND user_id <> :senderId`
+* 목적: 발신자 제외 미읽음 증가
+
+`findUserIdsByRoomId`:
+
+* SQL: roomId 기준 멤버 user_id 조회
+* 목적: 브로드캐스트 대상 계산
+
+`findCustomNickname`:
+
+* JPQL: friend 관계에서 customNickname 조회
+* 목적: 수신자 관점 표시 닉네임 우선순위 지원
+
+== 9. WebSocket 경로 규약
+
+[source,yaml]
+----
+include::../../src/main/resources/application-web.yml[lines=1..20]
+----
+
+* endpoint: `/api/ws-chat`
+* publish prefix: `/api/pub`
+* subscribe prefix: `/api/sub`
+* chat message path: `/chat/message`
+* chat room path: `/chat/rooms`
+
+== 10. 운영 체크리스트
+
+. 프론트 CONNECT 시 Authorization 헤더 포함
+. `/api/pub/chat/message` publish 사용
+. 사용자 큐/룸 구독 경로 정확히 일치
+. roomId 기준 다중 구독 정리(enter/leave)
+. 중복 수신 대비 messageId dedupe
+
+== 11. 확장 고려사항
+
+* 브로드캐스트 신뢰성 강화 필요 시 Outbox + 비동기 퍼블리셔 도입
+* 브로커 확장 시 simple broker -> 외부 브로커 relay 전환 검토

--- a/docs/feature-specs/chat-message-send-and-broadcast.adoc
+++ b/docs/feature-specs/chat-message-send-and-broadcast.adoc
@@ -73,6 +73,8 @@ include::../../src/main/java/com/chat_server/chatmessage/controller/ChatMessageC
 
 * `@MessageMapping("chat/message")`: 전송 요청 진입
 * `@MessageMapping("chat/broadcast")`: 릴레이 요청 진입
+** 인증 사용자의 `senderId`와 payload `senderId` 일치 여부 검증
+** `roomId`에 대한 멤버십 검증 후에만 릴레이 수행
 
 === 5.2 퍼사드 오케스트레이션
 
@@ -193,6 +195,16 @@ include::../../src/main/java/com/chat_server/friend/repository/FriendRepository.
 * 목적: 룸 구독 경로로 이벤트 재발행
 * 입력: 응답 DTO
 
+=== 6.10 `ChatMessageController.receiveBroadcast`
+
+* 목적: 외부 브로드캐스트 요청 릴레이 전 보안 검증 수행
+* 입력: `ChatMessageResponse`, `Authentication`
+* 검증:
+** 인증 사용자 ID와 payload senderId 일치 여부
+** 요청 사용자 room 멤버십 여부
+* 성공 시: 룸 destination으로 릴레이
+* 실패 시: `IllegalArgumentException` 또는 멤버십 검증 예외
+
 === 6.8 `ChatListRepository` 쿼리 메서드
 
 * `upsertMembership`: 멤버십 보장
@@ -288,12 +300,15 @@ include::../../src/main/resources/application-web.yml[lines=1..20]
 * subscribe prefix: `/api/sub`
 * chat message path: `/chat/message`
 * chat room path: `/chat/rooms`
+* user-target destination: `/user/api/sub/chat/rooms/{roomId}`
 
 == 10. 운영 체크리스트
 
 . 프론트 CONNECT 시 Authorization 헤더 포함
 . `/api/pub/chat/message` publish 사용
-. 사용자 큐/룸 구독 경로 정확히 일치
+. `/api/pub/chat/broadcast` 호출 시 payload senderId를 인증 사용자와 동일하게 전송
+. 사용자 큐 구독: `/user/api/sub/chat/rooms/{roomId}`
+. 룸 구독: `/api/sub/chat/rooms/{roomId}`
 . roomId 기준 다중 구독 정리(enter/leave)
 . 중복 수신 대비 messageId dedupe
 

--- a/docs/feature-specs/chat-message-send-and-broadcast.adoc
+++ b/docs/feature-specs/chat-message-send-and-broadcast.adoc
@@ -4,6 +4,8 @@
 :sectnums:
 :source-highlighter: highlight.js
 
+NOTE: 본 문서는 팀 내 커뮤니케이션 기준에 맞춰 한국어 설명을 우선으로 유지한다.
+
 == 1. 문서 목적
 
 이 문서는 채팅 시스템의 *메시지 전송(send)* 및 *브로드캐스트(broadcast)* 기능을 기술 명세 관점에서 설명한다.

--- a/src/main/java/com/chat_server/chatlist/repository/ChatListRepository.java
+++ b/src/main/java/com/chat_server/chatlist/repository/ChatListRepository.java
@@ -4,8 +4,23 @@ import com.chat_server.chatlist.entity.ChatList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChatListRepository extends JpaRepository<ChatList, Long>,ChatListRepositoryCustom {
+    /**
+     * 채팅방-사용자 멤버십을 upsert 한다.
+     *
+     * <p>동작:
+     * <ul>
+     *   <li>신규 관계면 row를 생성한다.</li>
+     *   <li>이미 존재하면 no-op(자기 자신 업데이트)으로 중복 삽입을 방지한다.</li>
+     * </ul>
+     *
+     * @param roomId 대상 채팅방 ID
+     * @param userId 멤버십을 보장할 사용자 ID
+     */
     @Modifying
     @Query(value = """
     INSERT INTO chat_list (chat_room_id, user_id,unread_count, pinned, muted, archived)
@@ -14,6 +29,12 @@ public interface ChatListRepository extends JpaRepository<ChatList, Long>,ChatLi
     """, nativeQuery = true)
     void upsertMembership(long roomId, long userId);
 
+    /**
+     * 특정 채팅방에서 발신자를 제외한 멤버의 unread_count를 1 증가시킨다.
+     *
+     * @param roomId unread 증가 대상 채팅방 ID
+     * @param senderId 현재 메시지를 보낸 발신자 ID(증가 대상에서 제외)
+     */
     @Modifying(clearAutomatically = true)
     @Query(value = """
     UPDATE chat_list
@@ -25,4 +46,17 @@ public interface ChatListRepository extends JpaRepository<ChatList, Long>,ChatLi
         long roomId,
         long senderId
     );
+
+    /**
+     * 채팅방에 속한 사용자 ID 목록을 조회한다.
+     *
+     * @param roomId 조회 대상 채팅방 ID
+     * @return 채팅방 멤버 사용자 ID 리스트(없으면 빈 리스트)
+     */
+    @Query(value = """
+        SELECT user_id
+        FROM chat_list
+        WHERE chat_room_id = :roomId
+        """, nativeQuery = true)
+    List<Long> findUserIdsByRoomId(@Param("roomId") long roomId);
 }

--- a/src/main/java/com/chat_server/chatlist/service/ChatListService.java
+++ b/src/main/java/com/chat_server/chatlist/service/ChatListService.java
@@ -5,8 +5,40 @@ import com.chat_server.friend.dto.response.CursorPageResponse;
 import com.chat_server.friend.dto.response.UserFriendResponse;
 import jakarta.annotation.Nullable;
 
+import java.util.List;
+
 public interface ChatListService {
+    /**
+     * 커서 기반으로 채팅방 목록을 조회한다.
+     *
+     * @param userId 조회 사용자 ID
+     * @param limit 페이지 크기
+     * @param cursor 다음 페이지 조회를 위한 커서(없으면 첫 페이지)
+     * @return 채팅방 목록 + next cursor + hasNext 정보를 담은 응답
+     */
     CursorPageResponse<ChatRoomListResponse> getChatRoomListsByCursor(Long userId, int limit, @Nullable String cursor);
+
+    /**
+     * 채팅방-사용자 멤버십을 보장한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     */
     void ensureMembership(Long roomId, Long userId);
+
+    /**
+     * 발신자를 제외한 멤버 unread count를 증가시킨다.
+     *
+     * @param roomId 채팅방 ID
+     * @param senderId 발신자 ID
+     */
     void increaseUnreadCount(Long roomId, Long senderId);
+
+    /**
+     * 채팅방에 속한 멤버 사용자 ID 목록을 조회한다.
+     *
+     * @param roomId 채팅방 ID
+     * @return 멤버 사용자 ID 리스트
+     */
+    List<Long> getRoomMemberUserIds(Long roomId);
 }

--- a/src/main/java/com/chat_server/chatlist/service/impl/ChatListServiceImpl.java
+++ b/src/main/java/com/chat_server/chatlist/service/impl/ChatListServiceImpl.java
@@ -8,6 +8,7 @@ import com.chat_server.common.cursor.ChatListCursorKey;
 import com.chat_server.friend.dto.response.CursorPageResponse;
 import jakarta.annotation.Nullable;
 import java.time.ZoneOffset;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,6 +25,21 @@ public class ChatListServiceImpl implements ChatListService {
 
     @Override
     @Transactional(readOnly = true)
+    /**
+     * 커서 기반 채팅방 목록을 조회한다.
+     *
+     * <p>동작:
+     * <ul>
+     *   <li>입력 커서를 디코딩한다.</li>
+     *   <li>레포지토리에서 {@code limit + 1} 형태의 slice를 조회해 hasNext를 판단한다.</li>
+     *   <li>마지막 요소 기준으로 next cursor를 인코딩한다.</li>
+     * </ul>
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @param limit 페이지 크기
+     * @param cursor 현재 페이지 커서(없으면 첫 페이지)
+     * @return 커서 페이지 응답
+     */
     public CursorPageResponse<ChatRoomListResponse> getChatRoomListsByCursor(Long userId, int limit,
         @Nullable String cursor) {
         // 1) 커서 디코드 (없거나 깨졌으면 null 반환되어 첫 페이지로 처리됨)
@@ -52,13 +68,45 @@ public class ChatListServiceImpl implements ChatListService {
     }
 
     @Override
+    /**
+     * 채팅방-사용자 멤버십을 upsert 한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     */
     public void ensureMembership(Long roomId, Long userId) {
         chatListRepository.upsertMembership(roomId, userId);
     }
 
     @Override
+    /**
+     * 발신자를 제외한 멤버의 unread count를 증가시킨다.
+     *
+     * @param roomId unread 증가 대상 채팅방 ID
+     * @param senderId 발신자 ID
+     */
     public void increaseUnreadCount(Long roomId, Long senderId) {
+        // 메시지 송신 시 발신자를 제외한 사용자 unread count를 증가시킨다.
+        log.info("increaseUnreadCount 호출");
+        log.debug("increaseUnreadCount params - roomId: {}, senderId: {}", roomId, senderId);
         chatListRepository.increaseUnreadCount(roomId, senderId);
+        log.debug("increaseUnreadCount 완료 - roomId: {}, senderId: {}", roomId, senderId);
+    }
 
+    @Override
+    @Transactional(readOnly = true)
+    /**
+     * 채팅방 멤버 사용자 ID 목록을 조회한다.
+     *
+     * @param roomId 대상 채팅방 ID
+     * @return 멤버 사용자 ID 리스트(없으면 빈 리스트)
+     */
+    public List<Long> getRoomMemberUserIds(Long roomId) {
+        // 채팅방 브로드캐스트 대상 사용자 목록을 조회한다.
+        log.info("getRoomMemberUserIds 호출");
+        log.debug("getRoomMemberUserIds params - roomId: {}", roomId);
+        List<Long> userIds = chatListRepository.findUserIdsByRoomId(roomId);
+        log.debug("getRoomMemberUserIds return - userIds: {}", userIds);
+        return userIds;
     }
 }

--- a/src/main/java/com/chat_server/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/com/chat_server/chatmessage/controller/ChatMessageController.java
@@ -3,6 +3,7 @@ package com.chat_server.chatmessage.controller;
 import com.chat_server.chatmessage.dto.request.ChatSendRequest;
 import com.chat_server.chatmessage.dto.response.ChatMessageResponse;
 import com.chat_server.chatmessage.service.ChatMessageFacadeService;
+import com.chat_server.chatroom.service.ChatRoomQueryService;
 import com.chat_server.user.dto.response.AuthenticatedUser;
 import com.chat_server.websocket.broadcaster.ChatMessageBroadCaster;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class ChatMessageController {
 
     private final ChatMessageFacadeService messageFacadeService;
     private final ChatMessageBroadCaster chatMessageBroadCaster;
+    private final ChatRoomQueryService chatRoomQueryService;
 
     /**
      * 프론트에서 전송한 메시지를 저장하고 대상자에게 실시간 전파한다.
@@ -44,13 +46,31 @@ public class ChatMessageController {
      * 브로드캐스트 요청을 받아 현재 구독 중인 프론트 클라이언트에게 즉시 릴레이한다.
      *
      * @param response 프론트/외부에서 전달한 채팅 메시지 응답 payload
+     * @param authentication 현재 STOMP 세션 인증 정보(내부 principal에 userId 포함)
+     * @throws IllegalArgumentException payload senderId와 인증 사용자 ID가 일치하지 않을 경우
      */
     @MessageMapping("chat/broadcast")
-    public void receiveBroadcast(ChatMessageResponse response) {
+    public void receiveBroadcast(ChatMessageResponse response, Authentication authentication) {
         log.info("receiveBroadcast 호출");
-        log.debug("receiveBroadcast params - response: {}", response);
+        log.debug("receiveBroadcast params - response: {}, authentication: {}", response, authentication);
+
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        Long userId = authenticatedUser.userId();
+        log.debug("receiveBroadcast authenticated userId: {}", userId);
+
+        // 클라이언트가 보낸 senderId 위변조를 방지한다.
+        if (!userId.equals(response.sender().senderId())) {
+            log.info("receiveBroadcast senderId 불일치");
+            log.debug("receiveBroadcast invalid sender - tokenUserId: {}, payloadSenderId: {}",
+                    userId, response.sender().senderId());
+            throw new IllegalArgumentException("senderId does not match authenticated user");
+        }
+
+        // 브로드캐스트 요청 사용자와 채팅방 멤버십을 검증한다.
+        chatRoomQueryService.validateMemberOrThrow(response.roomId(), userId);
+
         chatMessageBroadCaster.relayRoomBroadcast(response);
-        log.debug("receiveBroadcast 완료 - roomId: {}", response.roomId());
+        log.debug("receiveBroadcast 완료 - roomId: {}, userId: {}", response.roomId(), userId);
     }
 
 }

--- a/src/main/java/com/chat_server/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/com/chat_server/chatmessage/controller/ChatMessageController.java
@@ -1,16 +1,15 @@
 package com.chat_server.chatmessage.controller;
 
 import com.chat_server.chatmessage.dto.request.ChatSendRequest;
+import com.chat_server.chatmessage.dto.response.ChatMessageResponse;
 import com.chat_server.chatmessage.service.ChatMessageFacadeService;
 import com.chat_server.user.dto.response.AuthenticatedUser;
+import com.chat_server.websocket.broadcaster.ChatMessageBroadCaster;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Slf4j
 @Controller
@@ -18,19 +17,40 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ChatMessageController {
 
     private final ChatMessageFacadeService messageFacadeService;
+    private final ChatMessageBroadCaster chatMessageBroadCaster;
+
+    /**
+     * 프론트에서 전송한 메시지를 저장하고 대상자에게 실시간 전파한다.
+     *
+     * @param chatSendRequest 전송할 메시지 본문(채팅방 ID, 타입, 텍스트 포함)
+     * @param authentication 현재 STOMP 세션 인증 정보(내부 principal에 userId 포함)
+     * @throws ClassCastException principal 타입이 {@link AuthenticatedUser}가 아닐 경우
+     */
     @MessageMapping("chat/message")
     public void sendMessage(
                         ChatSendRequest chatSendRequest,
                         Authentication authentication
                         ) {
-        log.info("chat message controller start");
-//        log.info("user id: {}", authenticatedUser.userId());
-//        Long user = authenticatedUser.userId();
+        log.info("sendMessage 호출");
+        log.debug("sendMessage params - chatSendRequest: {}", chatSendRequest);
         AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
         Long userId= authenticatedUser.userId();
-        log.info("userId: {}",userId);
-        log.info("chat message controller end");
+        log.debug("sendMessage auth principal userId: {}", userId);
         messageFacadeService.sendMessage(chatSendRequest,userId);
+        log.debug("sendMessage 완료 - roomId: {}, userId: {}", chatSendRequest.roomId(), userId);
+    }
+
+    /**
+     * 브로드캐스트 요청을 받아 현재 구독 중인 프론트 클라이언트에게 즉시 릴레이한다.
+     *
+     * @param response 프론트/외부에서 전달한 채팅 메시지 응답 payload
+     */
+    @MessageMapping("chat/broadcast")
+    public void receiveBroadcast(ChatMessageResponse response) {
+        log.info("receiveBroadcast 호출");
+        log.debug("receiveBroadcast params - response: {}", response);
+        chatMessageBroadCaster.relayRoomBroadcast(response);
+        log.debug("receiveBroadcast 완료 - roomId: {}", response.roomId());
     }
 
 }

--- a/src/main/java/com/chat_server/chatmessage/service/impl/ChatMessageFacadeServiceImpl.java
+++ b/src/main/java/com/chat_server/chatmessage/service/impl/ChatMessageFacadeServiceImpl.java
@@ -10,9 +10,10 @@ import com.chat_server.chatmessage.service.ChatMessageService;
 import com.chat_server.chatroom.entity.ChatRoom;
 import com.chat_server.chatroom.service.ChatRoomQueryService;
 import com.chat_server.chatroom.service.ChatRoomService;
+import com.chat_server.user.service.UserDisplayNameService;
 import com.chat_server.userblock.service.UserBlockService;
 import com.chat_server.websocket.broadcaster.ChatMessageBroadCaster;
-import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,9 +34,29 @@ public class ChatMessageFacadeServiceImpl implements ChatMessageFacadeService {
     private final ChatMessageService chatMessageService;
     private final ChatRoomService chatRoomService;
     private final ChatListService chatListService;
+    private final UserDisplayNameService userDisplayNameService;
 
     @Override
+    /**
+     * 메시지 전송 전체 플로우를 오케스트레이션한다.
+     *
+     * <p>동작:
+     * <ul>
+     *   <li>채팅방/상대 멤버 조회</li>
+     *   <li>전송 권한/차단 검증</li>
+     *   <li>메시지 저장 및 방/목록 메타 업데이트</li>
+     *   <li>수신자별 display nickname/mine 반영 응답 생성 후 사용자별 브로드캐스트</li>
+     * </ul>
+     *
+     * @param request 메시지 전송 요청 DTO
+     * @param userId 발신자 사용자 ID
+     * @throws RuntimeException 채팅방/멤버 미존재, 권한 오류, 차단 관계 등 도메인 예외 발생 가능
+     */
     public void sendMessage(ChatSendRequest request, Long userId) {
+        // 메서드 시작 로그는 간단하게 info로 남긴다.
+        log.info("sendMessage 호출");
+        // 상세 파라미터는 debug에만 남겨 운영 로그 노이즈를 줄인다.
+        log.debug("sendMessage params - request: {}, userId: {}", request, userId);
         Long roomId = request.roomId();
         String messageType = request.messageType();
         String message = request.text();
@@ -49,35 +70,91 @@ public class ChatMessageFacadeServiceImpl implements ChatMessageFacadeService {
         updateRoomAndChatListOnSend(room, chatMessage);
         chatListService.increaseUnreadCount(roomId, userId);
 
-        Long messageId = chatMessage.getId();
-        String messageContent = chatMessage.getMessageContent();
-        LocalDateTime createdAt = chatMessage.getCreatedAt();
+        // 채팅방 멤버 목록을 조회하여 사용자별(수신자별) payload를 생성/전송한다.
+        List<Long> roomMemberUserIds = chatListService.getRoomMemberUserIds(roomId);
+        log.debug("sendMessage roomMemberUserIds: {}", roomMemberUserIds);
+        for (Long receiverUserId : roomMemberUserIds) {
+            ChatMessageResponse response = createResponseForReceiver(chatMessage, roomId, userId, receiverUserId);
+            chatMessageBroadCaster.broadcastMessage(receiverUserId, response);
+            log.debug("sendMessage broadcast 완료 - receiverUserId: {}, response: {}", receiverUserId, response);
+        }
+        log.debug("sendMessage 완료 - roomId: {}, messageId: {}", roomId, chatMessage.getId());
+    }
+
+    /**
+     * 발신자의 전송 가능 여부를 검증한다.
+     *
+     * @param room 메시지를 보내려는 채팅방
+     * @param userId 발신자 사용자 ID
+     * @param memberId 상대 멤버 사용자 ID
+     * @param request 원본 전송 요청(디버그 추적용)
+     * @throws RuntimeException 멤버십 없음/차단됨 등 검증 실패 시 도메인 예외
+     */
+    private void validateSendPermission(ChatRoom room, Long userId, Long memberId, ChatSendRequest request) {
+        // 송신자 권한 및 차단 상태를 검증한다.
+        log.info("validateSendPermission 호출");
+        log.debug("validateSendPermission params - roomId: {}, userId: {}, memberId: {}, request: {}",
+                room.getId(), userId, memberId, request);
+        chatRoomQueryService.validateMemberOrThrow(room.getId(), userId);
+        userBlockService.validateSenderNotBlocked(userId, memberId);
+        log.debug("validateSendPermission 완료 - roomId: {}, userId: {}", room.getId(), userId);
+    }
+
+    /**
+     * 메시지 저장 후 채팅방의 마지막 메시지 메타 정보를 동기화한다.
+     *
+     * @param room 대상 채팅방 엔티티
+     * @param chatMessage 방금 저장한 메시지 엔티티
+     */
+    private void updateRoomAndChatListOnSend(ChatRoom room, ChatMessage chatMessage) {
+        // 채팅방 마지막 메시지 정보를 동기화한다.
+        log.info("updateRoomAndChatListOnSend 호출");
+        log.debug("updateRoomAndChatListOnSend params - roomId: {}, chatMessageId: {}", room.getId(), chatMessage.getId());
+        chatRoomService.updateLastMessageInfo(room, chatMessage);
+        log.debug("updateRoomAndChatListOnSend 완료 - roomId: {}, lastMessageId: {}", room.getId(), chatMessage.getId());
+    }
+
+    /**
+     * 수신자 기준 display nickname 우선순위(친구 커스텀 닉네임 -> 사용자 기본 닉네임)를 반영한다.
+     *
+     * @param chatMessage 저장된 메시지 엔티티
+     * @param roomId 메시지가 속한 채팅방 ID
+     * @param senderId 발신자 사용자 ID
+     * @param receiverUserId 현재 응답을 만들 수신자 사용자 ID
+     * @return 수신자 관점(표시 닉네임/mine)이 반영된 채팅 응답 DTO
+     */
+    private ChatMessageResponse createResponseForReceiver(
+            ChatMessage chatMessage,
+            Long roomId,
+            Long senderId,
+            Long receiverUserId
+    ) {
+        log.info("createResponseForReceiver 호출");
+        log.debug("createResponseForReceiver params - chatMessageId: {}, roomId: {}, senderId: {}, receiverUserId: {}",
+                chatMessage.getId(), roomId, senderId, receiverUserId);
+
+        // 수신자별 display nickname을 계산한다.
+        String displayNickname = userDisplayNameService
+                .resolveDisplayName(senderId, receiverUserId)
+                .orElse(chatMessage.getSender().getNickname());
+        boolean mine = senderId.equals(receiverUserId);
 
         ChatMessageSenderResponse sender = new ChatMessageSenderResponse(
-                userId,
+                senderId,
                 chatMessage.getSender().getUuid(),
-                chatMessage.getSender().getNickname(),
+                displayNickname,
                 null,
-                true
+                mine
         );
 
         ChatMessageResponse response = new ChatMessageResponse(
-                messageId,
+                chatMessage.getId(),
                 roomId,
                 sender,
-                messageContent,
-                createdAt
+                chatMessage.getMessageContent(),
+                chatMessage.getCreatedAt()
         );
-
-        chatMessageBroadCaster.broadcastMessage(response);
-    }
-
-    private void validateSendPermission(ChatRoom room, Long userId, Long memberId, ChatSendRequest request) {
-        chatRoomQueryService.validateMemberOrThrow(room.getId(), userId);
-        userBlockService.validateSenderNotBlocked(userId, memberId);
-    }
-
-    private void updateRoomAndChatListOnSend(ChatRoom room, ChatMessage chatMessage) {
-        chatRoomService.updateLastMessageInfo(room, chatMessage);
+        log.debug("createResponseForReceiver return - response: {}", response);
+        return response;
     }
 }

--- a/src/main/java/com/chat_server/chatroom/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/chat_server/chatroom/exception/ChatRoomNotFoundException.java
@@ -1,11 +1,22 @@
 package com.chat_server.chatroom.exception;
 
-public class ChatRoomNotFoundException extends RuntimeException {
+import com.chat_server.common.dto.exception.NotFoundException;
+import com.chat_server.error.enumulation.ErrorCode;
+
+public class ChatRoomNotFoundException extends NotFoundException {
+    /**
+     * 채팅방 미존재 상황을 구체 메시지로 생성한다.
+     *
+     * @param message 프론트/로그에 전달할 상세 메시지
+     */
     public ChatRoomNotFoundException(String message) {
-        super(message);
+        super(ErrorCode.CHAT_ROOM_NOT_FOUND, message);
     }
 
+    /**
+     * 채팅방 미존재 기본 예외를 생성한다.
+     */
     public ChatRoomNotFoundException() {
-        super("chat room not found");
+        super(ErrorCode.CHAT_ROOM_NOT_FOUND, "chat room not found");
     }
 }

--- a/src/main/java/com/chat_server/common/dto/exception/ConflictException.java
+++ b/src/main/java/com/chat_server/common/dto/exception/ConflictException.java
@@ -1,5 +1,8 @@
 package com.chat_server.common.dto.exception;
 
+import com.chat_server.error.enumulation.ErrorCode;
+import com.chat_server.error.exception.BusinessException;
+
 /**
  * packageName    : com.chat_server.common.dto
  * fileName       : ConfictException
@@ -11,13 +14,31 @@ package com.chat_server.common.dto.exception;
  * -----------------------------------------------------------
  * 25. 2. 27.        parkminsu       최초 생성
  */
-public class ConflictException extends RuntimeException {
+public class ConflictException extends BusinessException {
 
+    /**
+     * 일반 충돌(CONFLICT) 기본 예외를 생성한다.
+     */
     public ConflictException() {
-        super("conflict");
+        super(ErrorCode.CONFLICT, "conflict");
     }
 
+    /**
+     * 일반 충돌(CONFLICT) 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 충돌 원인 설명 메시지
+     */
     public ConflictException(String message) {
-        super(message);
+        super(ErrorCode.CONFLICT, message);
+    }
+
+    /**
+     * 하위 도메인 예외에서 사용할 커스텀 충돌 코드를 받아 예외를 생성한다.
+     *
+     * @param errorCode 충돌 계열 도메인 에러 코드
+     * @param message 상세 메시지
+     */
+    protected ConflictException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
     }
 }

--- a/src/main/java/com/chat_server/common/dto/exception/NotFoundException.java
+++ b/src/main/java/com/chat_server/common/dto/exception/NotFoundException.java
@@ -1,5 +1,8 @@
 package com.chat_server.common.dto.exception;
 
+import com.chat_server.error.enumulation.ErrorCode;
+import com.chat_server.error.exception.BusinessException;
+
 /**
  * packageName    : com.chat_server.common.dto.exception
  * fileName       : NotFoundException
@@ -11,12 +14,30 @@ package com.chat_server.common.dto.exception;
  * -----------------------------------------------------------
  * 25. 2. 27.        parkminsu       최초 생성
  */
-public class NotFoundException extends RuntimeException {
+public class NotFoundException extends BusinessException {
+    /**
+     * 일반 리소스 미존재(NOT_FOUND) 기본 예외를 생성한다.
+     */
     public NotFoundException() {
-        super("not found");
+        super(ErrorCode.NOT_FOUND, "not found");
     }
 
+    /**
+     * 일반 리소스 미존재(NOT_FOUND) 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 미존재 원인 설명 메시지
+     */
     public NotFoundException(String message) {
-        super(message);
+        super(ErrorCode.NOT_FOUND, message);
+    }
+
+    /**
+     * 하위 도메인 예외에서 사용할 커스텀 404 코드를 받아 예외를 생성한다.
+     *
+     * @param errorCode 미존재 계열 도메인 에러 코드
+     * @param message 상세 메시지
+     */
+    protected NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
     }
 }

--- a/src/main/java/com/chat_server/common/dto/exception/ValidationException.java
+++ b/src/main/java/com/chat_server/common/dto/exception/ValidationException.java
@@ -1,5 +1,8 @@
 package com.chat_server.common.dto.exception;
 
+import com.chat_server.error.enumulation.ErrorCode;
+import com.chat_server.error.exception.BusinessException;
+
 /**
  * packageName    : com.chat_server.common.dto.exception
  * fileName       : ValidationException
@@ -11,11 +14,20 @@ package com.chat_server.common.dto.exception;
  * -----------------------------------------------------------
  * 25. 2. 27.        parkminsu       최초 생성
  */
-public class ValidationException extends RuntimeException {
+public class ValidationException extends BusinessException {
+    /**
+     * 요청 데이터 검증 실패 기본 예외를 생성한다.
+     */
     public ValidationException() {
+        super(ErrorCode.VALIDATION_ERROR, "validation error");
     }
 
+    /**
+     * 요청 데이터 검증 실패 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 검증 실패 상세 메시지
+     */
     public ValidationException(String message) {
-        super(message);
+        super(ErrorCode.VALIDATION_ERROR, message);
     }
 }

--- a/src/main/java/com/chat_server/common/exception/AccessTokenMissingException.java
+++ b/src/main/java/com/chat_server/common/exception/AccessTokenMissingException.java
@@ -1,5 +1,8 @@
 package com.chat_server.common.exception;
 
+import com.chat_server.error.enumulation.ErrorCode;
+import com.chat_server.error.exception.BusinessException;
+
 /**
  * packageName    : com.chat_server.common.exception
  * fileName       : AccessTokenMissingException
@@ -12,12 +15,20 @@ package com.chat_server.common.exception;
  * 25. 5. 22.        parkminsu       최초 생성
  */
 
-public class AccessTokenMissingException extends RuntimeException {
+public class AccessTokenMissingException extends BusinessException {
+    /**
+     * Access Token 누락 기본 예외를 생성한다.
+     */
     public AccessTokenMissingException() {
-        super("token missing");
+        super(ErrorCode.ACCESS_TOKEN_MISSING, "token missing");
     }
 
+    /**
+     * Access Token 누락 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 누락 원인 상세 메시지
+     */
     public AccessTokenMissingException(String message) {
-        super(message);
+        super(ErrorCode.ACCESS_TOKEN_MISSING, message);
     }
 }

--- a/src/main/java/com/chat_server/common/propertis/CustomProperties.java
+++ b/src/main/java/com/chat_server/common/propertis/CustomProperties.java
@@ -35,6 +35,18 @@ public class CustomProperties {
     public static class Error {
         private Map<String, String> messages;
 
+        /**
+         * ErrorCode enum 기반으로 사용자 노출 메시지를 조회한다.
+         *
+         * <p>기능:
+         * <ul>
+         *   <li>ErrorCode가 null이면 NOT_DEFINE 메시지로 fallback 한다.</li>
+         *   <li>ErrorCode가 존재하면 enum name을 문자열 키로 변환해 조회한다.</li>
+         * </ul>
+         *
+         * @param errorCode 메시지를 조회할 에러 코드(enum)
+         * @return 에러 코드에 대응하는 메시지(없으면 NOT_DEFINE 또는 기본 문구)
+         */
         public String getMessage(ErrorCode errorCode) {
             if (errorCode == null) {
                 return getMessage("NOT_DEFINE");
@@ -42,6 +54,19 @@ public class CustomProperties {
             return getMessage(errorCode.name());
         }
 
+        /**
+         * 문자열 코드 기반으로 사용자 노출 메시지를 조회한다.
+         *
+         * <p>기능:
+         * <ul>
+         *   <li>messages 설정이 비어 있으면 하드코딩 기본 문구를 반환한다.</li>
+         *   <li>errorCode가 null/blank이면 NOT_DEFINE 메시지를 반환한다.</li>
+         *   <li>해당 키가 없으면 NOT_DEFINE 메시지로 fallback 한다.</li>
+         * </ul>
+         *
+         * @param errorCode yml messages 맵의 키 값(예: USER_NOT_FOUND)
+         * @return 키에 매핑된 메시지 또는 fallback 메시지
+         */
         public String getMessage(String errorCode) {
             if (messages == null || messages.isEmpty()) {
                 return "알 수 없는 에러 입니다.";

--- a/src/main/java/com/chat_server/error/dto/ErrorResponse.java
+++ b/src/main/java/com/chat_server/error/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.chat_server.error.dto;
+
+import com.chat_server.error.enumulation.ErrorCode;
+
+/**
+ * 전역 예외 응답 바디를 표현하는 DTO.
+ *
+ * @param errorCode 에러 코드
+ * @param message 사용자 노출 메시지
+ */
+public record ErrorResponse(
+        ErrorCode errorCode,
+        String message
+) {
+}

--- a/src/main/java/com/chat_server/error/enumulation/ErrorCode.java
+++ b/src/main/java/com/chat_server/error/enumulation/ErrorCode.java
@@ -6,17 +6,42 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED),
+    ACCESS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED),
     NO_PERMISSION(HttpStatus.FORBIDDEN),
+    NOT_FOUND(HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND),
+    USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND),
+    GENDER_NOT_FOUND(HttpStatus.NOT_FOUND),
     NOT_DEFINE(HttpStatus.INTERNAL_SERVER_ERROR),
+    CONFLICT(HttpStatus.CONFLICT),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT),
+    USER_BLOCK_EXISTS(HttpStatus.CONFLICT),
     INVALID_INPUT(HttpStatus.BAD_REQUEST),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST);
 
     private final HttpStatus status;
 
+    /**
+     * 에러 코드 enum 항목과 HTTP 상태를 매핑한다.
+     *
+     * @param status 해당 에러 코드의 HTTP 상태
+     */
     ErrorCode(HttpStatus status) {
         this.status = status;
     }
 
+    /**
+     * 문자열 코드를 {@link ErrorCode}로 안전하게 변환한다.
+     *
+     * <p>예외 상황:
+     * <ul>
+     *   <li>코드가 null/blank 이거나 enum에 없는 값이면 {@link #NOT_DEFINE}을 반환한다.</li>
+     * </ul>
+     *
+     * @param code 변환 대상 문자열 코드
+     * @return 변환된 ErrorCode 또는 NOT_DEFINE
+     */
     public static ErrorCode from(String code) {
         if (code == null || code.isBlank()) {
             return NOT_DEFINE;

--- a/src/main/java/com/chat_server/error/exception/BusinessException.java
+++ b/src/main/java/com/chat_server/error/exception/BusinessException.java
@@ -1,0 +1,34 @@
+package com.chat_server.error.exception;
+
+import com.chat_server.error.enumulation.ErrorCode;
+import lombok.Getter;
+
+/**
+ * ErrorCode 기반 전역 예외 처리를 위해 사용하는 비즈니스 예외.
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    /**
+     * ErrorCode 이름을 메시지로 사용하는 비즈니스 예외를 생성한다.
+     *
+     * @param errorCode 예외 의미/HTTP 상태를 나타내는 코드
+     */
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.name());
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * ErrorCode와 사용자 노출 메시지를 함께 가지는 비즈니스 예외를 생성한다.
+     *
+     * @param errorCode 예외 의미/HTTP 상태를 나타내는 코드
+     * @param message 사용자/로그에 전달할 상세 메시지
+     */
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/chat_server/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/chat_server/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,172 @@
+package com.chat_server.error.handler;
+
+import com.chat_server.common.propertis.CustomProperties;
+import com.chat_server.error.dto.ErrorResponse;
+import com.chat_server.error.enumulation.ErrorCode;
+import com.chat_server.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * ErrorCode + application-custom.yml 메시지를 기반으로 예외를 응답한다.
+ */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final CustomProperties customProperties;
+
+    /**
+     * 서비스/도메인 계층에서 발생한 {@link BusinessException}을 공통 에러 응답으로 변환한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>예외 내부의 {@link ErrorCode}를 그대로 사용해 HTTP 상태 코드를 결정한다.</li>
+     *   <li>예외 메시지가 비어 있지 않으면 해당 메시지를 우선 사용한다.</li>
+     *   <li>예외 메시지가 비어 있으면 yml 메시지를 fallback으로 사용한다.</li>
+     * </ul>
+     *
+     * @param exception 비즈니스 규칙 위반 시 서비스 계층에서 던진 예외
+     * @return errorCode/message가 채워진 {@link ErrorResponse}와 해당 상태 코드의 {@link ResponseEntity}
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
+        log.info("handleBusinessException 호출");
+        log.debug("handleBusinessException params - exceptionMessage: {}, errorCode: {}",
+                exception.getMessage(), exception.getErrorCode());
+        ErrorCode errorCode = exception.getErrorCode();
+        ErrorResponse response = createErrorResponse(errorCode, exception.getMessage());
+        log.debug("handleBusinessException return - response: {}", response);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /**
+     * 입력 파라미터가 유효하지 않을 때 발생한 {@link IllegalArgumentException}을 처리한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>에러 코드를 {@link ErrorCode#INVALID_INPUT}으로 고정한다.</li>
+     *   <li>예외 메시지가 없으면 yml 기본 메시지를 사용한다.</li>
+     * </ul>
+     *
+     * @param exception 잘못된 입력값/인자 검증 실패로 발생한 런타임 예외
+     * @return INVALID_INPUT 코드 기반의 {@link ErrorResponse}
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
+        log.info("handleIllegalArgumentException 호출");
+        log.debug("handleIllegalArgumentException params - exceptionMessage: {}", exception.getMessage());
+        ErrorResponse response = createErrorResponse(ErrorCode.INVALID_INPUT, exception.getMessage());
+        log.debug("handleIllegalArgumentException return - response: {}", response);
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(response);
+    }
+
+    /**
+     * 명시적으로 분류되지 않은 {@link RuntimeException}을 규칙 기반으로 분류해 처리한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>예외 클래스명 패턴(Validation/NotFound/Conflict/Exists)을 기반으로 {@link ErrorCode}를 결정한다.</li>
+     *   <li>분류 불가한 경우 {@link ErrorCode#NOT_DEFINE}를 사용한다.</li>
+     * </ul>
+     *
+     * @param exception BusinessException, IllegalArgumentException 외 런타임 예외
+     * @return 분류된 에러 코드에 대응하는 {@link ErrorResponse}
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+        log.info("handleRuntimeException 호출");
+        log.debug("handleRuntimeException params - exceptionClass: {}, exceptionMessage: {}",
+                exception.getClass().getName(), exception.getMessage(), exception);
+        ErrorCode errorCode = resolveRuntimeErrorCode(exception);
+        ErrorResponse response = createErrorResponse(errorCode, exception.getMessage());
+        log.debug("handleRuntimeException return - response: {}", response);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /**
+     * 위 핸들러에서 처리하지 못한 모든 체크 예외/예외를 최종 처리한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>시스템 예외를 {@link ErrorCode#NOT_DEFINE}으로 응답해 API 응답 형식을 유지한다.</li>
+     *   <li>내부 예외 상세는 로그(debug)로 기록하고, 응답은 공통 포맷으로 반환한다.</li>
+     * </ul>
+     *
+     * @param exception 처리되지 않은 최종 예외
+     * @return NOT_DEFINE 코드 기반의 {@link ErrorResponse}
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.info("handleException 호출");
+        log.debug("handleException params - exceptionClass: {}, exceptionMessage: {}",
+                exception.getClass().getName(), exception.getMessage(), exception);
+        ErrorResponse response = createErrorResponse(ErrorCode.NOT_DEFINE, exception.getMessage());
+        log.debug("handleException return - response: {}", response);
+        return ResponseEntity.status(ErrorCode.NOT_DEFINE.getStatus()).body(response);
+    }
+
+    /**
+     * 공통 에러 응답 DTO를 생성한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>전달받은 errorCode를 기준으로 yml에서 기본 메시지(fallback)를 조회한다.</li>
+     *   <li>예외 메시지가 존재하면 해당 메시지를 사용하고, 비어 있으면 fallback 메시지를 사용한다.</li>
+     * </ul>
+     *
+     * @param errorCode 응답 상태/의미를 나타내는 에러 코드
+     * @param exceptionMessage 실제 예외에서 전달된 메시지(없을 수 있음)
+     * @return errorCode와 최종 message가 채워진 {@link ErrorResponse}
+     */
+    private ErrorResponse createErrorResponse(ErrorCode errorCode, String exceptionMessage) {
+        log.info("createErrorResponse 호출");
+        log.debug("createErrorResponse params - errorCode: {}, exceptionMessage: {}", errorCode, exceptionMessage);
+        String fallbackMessage = customProperties.getError().getMessage(errorCode);
+        String message = (exceptionMessage == null || exceptionMessage.isBlank()) ? fallbackMessage : exceptionMessage;
+        ErrorResponse response = new ErrorResponse(errorCode, message);
+        log.debug("createErrorResponse return - response: {}", response);
+        return response;
+    }
+
+    /**
+     * 런타임 예외 클래스명을 기반으로 fallback {@link ErrorCode}를 계산한다.
+     *
+     * <p>기능:
+     * <ul>
+     *   <li>Validation 포함: {@link ErrorCode#VALIDATION_ERROR}</li>
+     *   <li>NotFound 포함: {@link ErrorCode#NOT_FOUND}</li>
+     *   <li>Conflict/Exists 포함: {@link ErrorCode#CONFLICT}</li>
+     *   <li>그 외: {@link ErrorCode#NOT_DEFINE}</li>
+     * </ul>
+     *
+     * <p>예외 상황:
+     * <ul>
+     *   <li>예외 객체 자체가 null인 경우 NPE가 발생할 수 있으므로, 호출부에서 null이 아닌 예외만 전달해야 한다.</li>
+     * </ul>
+     *
+     * @param exception 분류 대상 런타임 예외
+     * @return 분류 규칙에 따라 결정된 에러 코드
+     */
+    private ErrorCode resolveRuntimeErrorCode(RuntimeException exception) {
+        log.info("resolveRuntimeErrorCode 호출");
+        log.debug("resolveRuntimeErrorCode params - exceptionClass: {}", exception.getClass().getName());
+        String simpleName = exception.getClass().getSimpleName();
+        ErrorCode resolved;
+        if (simpleName.contains("Validation")) {
+            resolved = ErrorCode.VALIDATION_ERROR;
+        } else if (simpleName.contains("NotFound")) {
+            resolved = ErrorCode.NOT_FOUND;
+        } else if (simpleName.contains("Conflict") || simpleName.contains("Exists")) {
+            resolved = ErrorCode.CONFLICT;
+        } else {
+            resolved = ErrorCode.NOT_DEFINE;
+        }
+        log.debug("resolveRuntimeErrorCode return - resolved: {}", resolved);
+        return resolved;
+    }
+}

--- a/src/main/java/com/chat_server/friend/repository/FriendRepository.java
+++ b/src/main/java/com/chat_server/friend/repository/FriendRepository.java
@@ -2,7 +2,26 @@ package com.chat_server.friend.repository;
 
 import com.chat_server.friend.entity.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long>, FriendRepositoryCustom {
-
+    /**
+     * 사용자(userId)가 친구(friendUserId)에게 지정한 커스텀 닉네임을 조회한다.
+     *
+     * @param userId 닉네임을 설정한 사용자 ID(조회 주체)
+     * @param friendUserId 닉네임 대상 친구 사용자 ID
+     * @return 커스텀 닉네임 Optional(없거나 빈 문자열이면 empty)
+     */
+    @Query("""
+        select f.customNickname
+        from Friend f
+        where f.user.id = :userId
+          and f.friendUser.id = :friendUserId
+          and f.customNickname is not null
+          and f.customNickname <> ''
+        """)
+    Optional<String> findCustomNickname(@Param("userId") Long userId, @Param("friendUserId") Long friendUserId);
 }

--- a/src/main/java/com/chat_server/gender/exception/GenderNotFoundException.java
+++ b/src/main/java/com/chat_server/gender/exception/GenderNotFoundException.java
@@ -1,6 +1,7 @@
 package com.chat_server.gender.exception;
 
 import com.chat_server.common.dto.exception.NotFoundException;
+import com.chat_server.error.enumulation.ErrorCode;
 
 /**
  * packageName    : com.chat_server.gender.exception
@@ -14,11 +15,19 @@ import com.chat_server.common.dto.exception.NotFoundException;
  * 25. 2. 27.        parkminsu       최초 생성
  */
 public class GenderNotFoundException extends NotFoundException {
+    /**
+     * 성별 정보 미존재 기본 예외를 생성한다.
+     */
     public GenderNotFoundException() {
-        super();
+        super(ErrorCode.GENDER_NOT_FOUND, "gender not found");
     }
 
+    /**
+     * 성별 정보 미존재 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 성별 정보 조회 실패 상세 메시지
+     */
     public GenderNotFoundException(String message) {
-        super(message);
+        super(ErrorCode.GENDER_NOT_FOUND, message);
     }
 }

--- a/src/main/java/com/chat_server/user/exception/UserAleadyExistException.java
+++ b/src/main/java/com/chat_server/user/exception/UserAleadyExistException.java
@@ -1,6 +1,7 @@
 package com.chat_server.user.exception;
 
 import com.chat_server.common.dto.exception.ConflictException;
+import com.chat_server.error.enumulation.ErrorCode;
 
 /**
  * packageName    : com.chat_server.user.exception
@@ -14,11 +15,19 @@ import com.chat_server.common.dto.exception.ConflictException;
  * 25. 2. 27.        parkminsu       최초 생성
  */
 public class UserAleadyExistException extends ConflictException {
+    /**
+     * 사용자 중복(이미 존재) 기본 예외를 생성한다.
+     */
     public UserAleadyExistException() {
-        super();
+        super(ErrorCode.USER_ALREADY_EXISTS, "user already exists");
     }
 
+    /**
+     * 사용자 중복(이미 존재) 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 중복 원인 상세 메시지
+     */
     public UserAleadyExistException(String message) {
-        super(message);
+        super(ErrorCode.USER_ALREADY_EXISTS, message);
     }
 }

--- a/src/main/java/com/chat_server/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/chat_server/user/exception/UserNotFoundException.java
@@ -1,5 +1,8 @@
 package com.chat_server.user.exception;
 
+import com.chat_server.common.dto.exception.NotFoundException;
+import com.chat_server.error.enumulation.ErrorCode;
+
 /**
  * packageName    : com.chat_server.user.exception
  * fileName       : UserNotFoundException
@@ -11,13 +14,20 @@ package com.chat_server.user.exception;
  * -----------------------------------------------------------
  * 25. 5. 27.        parkminsu       최초 생성
  */
-public class UserNotFoundException extends RuntimeException {
+public class UserNotFoundException extends NotFoundException {
+    /**
+     * 사용자 미존재 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 사용자 조회 실패 상세 메시지
+     */
     public UserNotFoundException(String message) {
-        super(message);
+        super(ErrorCode.USER_NOT_FOUND, message);
     }
 
+    /**
+     * 사용자 미존재 기본 예외를 생성한다.
+     */
     public UserNotFoundException() {
-
-        super("user not found");
+        super(ErrorCode.USER_NOT_FOUND, "user not found");
     }
 }

--- a/src/main/java/com/chat_server/user/service/impl/UserDisplayNameServiceImpl.java
+++ b/src/main/java/com/chat_server/user/service/impl/UserDisplayNameServiceImpl.java
@@ -1,5 +1,7 @@
 package com.chat_server.user.service.impl;
 
+import com.chat_server.friend.repository.FriendRepository;
+import com.chat_server.user.entity.User;
 import com.chat_server.user.repository.UserRepository;
 import com.chat_server.user.service.UserDisplayNameService;
 import java.util.Optional;
@@ -14,12 +16,43 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserDisplayNameServiceImpl implements UserDisplayNameService {
 
+    private final FriendRepository friendRepository;
     private final UserRepository userRepository;
 
     @Override
+    /**
+     * 메시지 수신자 관점에서 발신자 display name을 결정한다.
+     *
+     * <p>우선순위:
+     * <ol>
+     *   <li>수신자가 발신자에게 지정한 친구 커스텀 닉네임</li>
+     *   <li>발신자의 기본 닉네임</li>
+     * </ol>
+     *
+     * @param senderId 발신자 사용자 ID
+     * @param receiverId 수신자 사용자 ID
+     * @return 우선순위에 따라 결정된 표시 이름 Optional
+     */
     public Optional<String> resolveDisplayName(Long senderId, Long receiverId) {
+        // 메서드 진입 로그는 info 레벨로 간단히 남긴다.
+        log.info("resolveDisplayName 호출");
+        // 파라미터 상세 값은 debug 레벨로 남겨 추적 가능성을 높인다.
+        log.debug("resolveDisplayName params - senderId: {}, receiverId: {}", senderId, receiverId);
 
+        // 1순위: 수신자 기준 친구 커스텀 닉네임(내가 상대에게 붙인 이름)
+        Optional<String> friendCustomNickname = friendRepository.findCustomNickname(receiverId, senderId);
+        log.debug("resolveDisplayName friendCustomNickname: {}", friendCustomNickname.orElse(null));
+        if (friendCustomNickname.isPresent()) {
+            log.debug("resolveDisplayName return(친구 커스텀 닉네임): {}", friendCustomNickname.get());
+            return friendCustomNickname;
+        }
 
-        return null;
+        // 2순위: 발신자가 설정한 기본 닉네임
+        Optional<String> senderNickname = userRepository.findById(senderId)
+                .map(User::getNickname)
+                .filter(nickname -> nickname != null && !nickname.isBlank());
+        log.debug("resolveDisplayName senderNickname: {}", senderNickname.orElse(null));
+        log.debug("resolveDisplayName return(기본 닉네임): {}", senderNickname.orElse(null));
+        return senderNickname;
     }
 }

--- a/src/main/java/com/chat_server/userblock/exception/UserBlockExistsException.java
+++ b/src/main/java/com/chat_server/userblock/exception/UserBlockExistsException.java
@@ -1,11 +1,22 @@
 package com.chat_server.userblock.exception;
 
-public class UserBlockExistsException extends RuntimeException{
+import com.chat_server.common.dto.exception.ConflictException;
+import com.chat_server.error.enumulation.ErrorCode;
+
+public class UserBlockExistsException extends ConflictException {
+    /**
+     * 이미 차단된 관계 기본 예외를 생성한다.
+     */
     public UserBlockExistsException(){
-        super("user block exist");
+        super(ErrorCode.USER_BLOCK_EXISTS, "user block exist");
     }
 
+    /**
+     * 이미 차단된 관계 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 차단 관계 충돌 상세 메시지
+     */
     public UserBlockExistsException(String message){
-        super(message);
+        super(ErrorCode.USER_BLOCK_EXISTS, message);
     }
 }

--- a/src/main/java/com/chat_server/userprofile/exception/UserProfileNotFoundException.java
+++ b/src/main/java/com/chat_server/userprofile/exception/UserProfileNotFoundException.java
@@ -1,12 +1,23 @@
 package com.chat_server.userprofile.exception;
 
-public class UserProfileNotFoundException extends RuntimeException{
+import com.chat_server.common.dto.exception.NotFoundException;
+import com.chat_server.error.enumulation.ErrorCode;
+
+public class UserProfileNotFoundException extends NotFoundException {
+    /**
+     * 사용자 프로필 미존재 기본 예외를 생성한다.
+     */
     public UserProfileNotFoundException(){
-        super("user profile not found");
+        super(ErrorCode.USER_PROFILE_NOT_FOUND, "user profile not found");
     }
 
+    /**
+     * 사용자 프로필 미존재 예외를 상세 메시지와 함께 생성한다.
+     *
+     * @param message 프로필 조회 실패 상세 메시지
+     */
     public UserProfileNotFoundException(String message){
-        super(message);
+        super(ErrorCode.USER_PROFILE_NOT_FOUND, message);
     }
 
 }

--- a/src/main/java/com/chat_server/websocket/broadcaster/ChatMessageBroadCaster.java
+++ b/src/main/java/com/chat_server/websocket/broadcaster/ChatMessageBroadCaster.java
@@ -3,5 +3,18 @@ package com.chat_server.websocket.broadcaster;
 import com.chat_server.chatmessage.dto.response.ChatMessageResponse;
 
 public interface ChatMessageBroadCaster {
-    void broadcastMessage( ChatMessageResponse response);
+    /**
+     * 특정 사용자 전용 destination으로 메시지를 전송한다.
+     *
+     * @param receiverUserId 수신자 사용자 ID
+     * @param response 전송할 채팅 응답 payload
+     */
+    void broadcastMessage(Long receiverUserId, ChatMessageResponse response);
+
+    /**
+     * 룸 구독 destination으로 브로드캐스트를 릴레이한다.
+     *
+     * @param response 릴레이할 채팅 응답 payload
+     */
+    void relayRoomBroadcast(ChatMessageResponse response);
 }

--- a/src/main/java/com/chat_server/websocket/broadcaster/impl/ChatMessageBroadCasterImpl.java
+++ b/src/main/java/com/chat_server/websocket/broadcaster/impl/ChatMessageBroadCasterImpl.java
@@ -17,11 +17,36 @@ public class ChatMessageBroadCasterImpl implements ChatMessageBroadCaster {
 
 
     @Override
-    public void broadcastMessage( ChatMessageResponse response) {
-        String payload = webSocketProperties.getSubPrefix()
-            + webSocketProperties.getChat().getRoomPath()
-            +"/" + response.roomId();
-        // Api 공통 응답이 있는데 그걸 사용해야하나?
-        messagingTemplate.convertAndSend(payload, response);
+    /**
+     * 수신자 사용자 전용 큐로 채팅 메시지를 전송한다.
+     *
+     * @param receiverUserId 수신자 사용자 ID
+     * @param response 전송할 메시지 응답 DTO
+     */
+    public void broadcastMessage(Long receiverUserId, ChatMessageResponse response) {
+        // 사용자별 display nickname/mine 값을 반영하기 위해 사용자 전용 큐로 전송한다.
+        log.info("broadcastMessage 호출");
+        log.debug("broadcastMessage params - receiverUserId: {}, response: {}", receiverUserId, response);
+        String userDestination = "/queue" + webSocketProperties.getChat().getRoomPath()
+                + "/" + response.roomId();
+        messagingTemplate.convertAndSendToUser(String.valueOf(receiverUserId), userDestination, response);
+        log.debug("broadcastMessage 완료 - userDestination: {}", userDestination);
+    }
+
+    @Override
+    /**
+     * 룸 구독 경로로 브로드캐스트를 릴레이한다.
+     *
+     * @param response 릴레이할 메시지 응답 DTO
+     */
+    public void relayRoomBroadcast(ChatMessageResponse response) {
+        // 프론트/외부에서 전달된 브로드캐스트 요청을 채팅방 구독 경로로 릴레이한다.
+        log.info("relayRoomBroadcast 호출");
+        log.debug("relayRoomBroadcast params - response: {}", response);
+        String roomDestination = webSocketProperties.getSubPrefix()
+                + webSocketProperties.getChat().getRoomPath()
+                + "/" + response.roomId();
+        messagingTemplate.convertAndSend(roomDestination, response);
+        log.debug("relayRoomBroadcast 완료 - roomDestination: {}", roomDestination);
     }
 }

--- a/src/main/java/com/chat_server/websocket/broadcaster/impl/ChatMessageBroadCasterImpl.java
+++ b/src/main/java/com/chat_server/websocket/broadcaster/impl/ChatMessageBroadCasterImpl.java
@@ -20,6 +20,9 @@ public class ChatMessageBroadCasterImpl implements ChatMessageBroadCaster {
     /**
      * 수신자 사용자 전용 큐로 채팅 메시지를 전송한다.
      *
+     * <p>destination 정책:
+     * {@code /user + subPrefix + roomPath + /{roomId}}
+     *
      * @param receiverUserId 수신자 사용자 ID
      * @param response 전송할 메시지 응답 DTO
      */
@@ -27,7 +30,8 @@ public class ChatMessageBroadCasterImpl implements ChatMessageBroadCaster {
         // 사용자별 display nickname/mine 값을 반영하기 위해 사용자 전용 큐로 전송한다.
         log.info("broadcastMessage 호출");
         log.debug("broadcastMessage params - receiverUserId: {}, response: {}", receiverUserId, response);
-        String userDestination = "/queue" + webSocketProperties.getChat().getRoomPath()
+        String userDestination = webSocketProperties.getSubPrefix()
+                + webSocketProperties.getChat().getRoomPath()
                 + "/" + response.roomId();
         messagingTemplate.convertAndSendToUser(String.valueOf(receiverUserId), userDestination, response);
         log.debug("broadcastMessage 완료 - userDestination: {}", userDestination);

--- a/src/main/resources/application-custom.yml
+++ b/src/main/resources/application-custom.yml
@@ -7,7 +7,18 @@ custom:
     messages:
       TOKEN_EXPIRED: "Access Token이 만료되었습니다."
       INVALID_TOKEN: "유효하지 않은 토큰입니다."
+      ACCESS_TOKEN_MISSING: "Access Token이 없습니다."
       NO_PERMISSION: "접근 권한이 없습니다."
+      NOT_FOUND: "요청한 리소스를 찾을 수 없습니다."
+      USER_NOT_FOUND: "사용자를 찾을 수 없습니다."
+      CHAT_ROOM_NOT_FOUND: "채팅방을 찾을 수 없습니다."
+      USER_PROFILE_NOT_FOUND: "사용자 프로필을 찾을 수 없습니다."
+      GENDER_NOT_FOUND: "성별 정보를 찾을 수 없습니다."
+      CONFLICT: "요청이 현재 상태와 충돌합니다."
+      USER_ALREADY_EXISTS: "이미 존재하는 사용자입니다."
+      USER_BLOCK_EXISTS: "이미 차단된 관계입니다."
+      INVALID_INPUT: "입력 값이 올바르지 않습니다."
+      VALIDATION_ERROR: "요청 데이터 검증에 실패했습니다."
       NOT_DEFINE: "정의되지 않은 오류 입니다."
 
   api:


### PR DESCRIPTION
### 변경 배경
- STOMP 기반 채팅 전송/브로드캐스트 흐름을 완성하고, 수신자별 payload(display nickname, mine) 전달을 보장하기 위함
- 메시지 전송 시 멤버십 upsert 및 unread 증가 로직을 포함해 채팅 목록 상태를 일관되게 유지하기 위함
- ErrorCode/BusinessException 기반 전역 오류 처리로 API 오류 응답을 표준화하기 위함

### 주요 변경 사항
- 기술 명세서 추가: `docs/feature-specs/chat-message-send-and-broadcast.adoc`
- ChatList 계층 확장:
  - `upsertMembership`, `increaseUnreadCount`, `findUserIdsByRoomId`
  - `ensureMembership`, `increaseUnreadCount`, `getRoomMemberUserIds` 노출
- 메시지 컨트롤러/퍼사드 개선:
  - `@MessageMapping("chat/message")`, `@MessageMapping("chat/broadcast")`
  - 권한/멤버십 검증 + 저장 + 메타 업데이트 + 수신자별 응답 생성 + 브로드캐스트
- 브로드캐스터 개선:
  - 사용자 대상 전송 `broadcastMessage(Long, ChatMessageResponse)`
  - 룸 릴레이 `relayRoomBroadcast(...)`
  - 목적지 prefix 정책 일원화
- 표시 닉네임 계산:
  - 친구 커스텀 닉네임 우선, 없으면 기본 닉네임 fallback
- 전역 오류 처리 통합:
  - `ErrorCode`, `BusinessException`, `ErrorResponse`, `GlobalExceptionHandler`
  - `application-custom.yml` 오류 메시지 매핑 확장

### 테스트
- 자동화 테스트는 환경(JDK/Gradle 호환) 이슈로 실행되지 않음
- 코드 경로/설정/문서 동기화 수동 점검 완료