### PR TITLE
채팅방 입장 시 DM 표시 이름 및 사용자별 그룹 커스텀 이름으로 제목 결정

### DIFF
--- a/src/main/java/com/chat_server/chatlist/repository/ChatListRepository.java
+++ b/src/main/java/com/chat_server/chatlist/repository/ChatListRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatListRepository extends JpaRepository<ChatList, Long>,ChatListRepositoryCustom {
     /**
@@ -59,4 +60,24 @@ public interface ChatListRepository extends JpaRepository<ChatList, Long>,ChatLi
         WHERE chat_room_id = :roomId
         """, nativeQuery = true)
     List<Long> findUserIdsByRoomId(@Param("roomId") long roomId);
+
+    /**
+     * 사용자가 특정 채팅방에 설정한 커스텀 방 이름을 조회한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 커스텀 방 이름(Optional)
+     */
+    @Query("""
+        select cl.customName
+        from ChatList cl
+        where cl.chatRoom.id = :roomId
+          and cl.user.id = :userId
+          and cl.customName is not null
+          and cl.customName <> ''
+        """)
+    Optional<String> findCustomNameByUserIdAndRoomId(
+            @Param("roomId") Long roomId,
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/chat_server/chatlist/service/ChatListService.java
+++ b/src/main/java/com/chat_server/chatlist/service/ChatListService.java
@@ -6,6 +6,7 @@ import com.chat_server.friend.dto.response.UserFriendResponse;
 import jakarta.annotation.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatListService {
     /**
@@ -41,4 +42,13 @@ public interface ChatListService {
      * @return 멤버 사용자 ID 리스트
      */
     List<Long> getRoomMemberUserIds(Long roomId);
+
+    /**
+     * 사용자가 설정한 채팅방 커스텀 이름을 조회한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 커스텀 이름(Optional)
+     */
+    Optional<String> getCustomRoomName(Long roomId, Long userId);
 }

--- a/src/main/java/com/chat_server/chatlist/service/impl/ChatListServiceImpl.java
+++ b/src/main/java/com/chat_server/chatlist/service/impl/ChatListServiceImpl.java
@@ -9,6 +9,7 @@ import com.chat_server.friend.dto.response.CursorPageResponse;
 import jakarta.annotation.Nullable;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -108,5 +109,11 @@ public class ChatListServiceImpl implements ChatListService {
         List<Long> userIds = chatListRepository.findUserIdsByRoomId(roomId);
         log.debug("getRoomMemberUserIds return - userIds: {}", userIds);
         return userIds;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<String> getCustomRoomName(Long roomId, Long userId) {
+        return chatListRepository.findCustomNameByUserIdAndRoomId(roomId, userId);
     }
 }

--- a/src/main/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImpl.java
+++ b/src/main/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImpl.java
@@ -6,16 +6,20 @@ import com.chat_server.chatmessage.service.ChatMessageService;
 import com.chat_server.chatroom.dto.response.ChatRoomEnterResponse;
 import com.chat_server.chatroom.dto.response.ChatRoomResult;
 import com.chat_server.chatroom.dto.response.ChatRoomSummaryResponse;
+import com.chat_server.chatroom.entity.ChatRoom;
+import com.chat_server.chatroom.enums.RoomType;
 import com.chat_server.chatroom.service.ChatRoomFacadeService;
 import com.chat_server.chatroom.service.ChatRoomQueryService;
 import com.chat_server.chatroom.service.ChatRoomService;
 import com.chat_server.chatroommember.service.ChatRoomMemberService;
 import com.chat_server.common.cursor.ChatMessageCursorCodec;
 import com.chat_server.common.cursor.ChatMessageCursorKey;
+import com.chat_server.user.service.UserDisplayNameService;
 import com.chat_server.user.service.UserService;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +37,7 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
     private final ChatMessageService chatMessageService;
     private final ChatRoomQueryService chatRoomQueryService;
     private final UserService userService;
+    private final UserDisplayNameService userDisplayNameService;
 
     /**
      * 채팅방 summary 정보를 조회한다.
@@ -91,7 +96,7 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
             nextCursor = ChatMessageCursorCodec.encode(lastAtEpochMillis, last.messageId());
         }
 
-        String title = room.getName() != null ? room.getName() : "";
+        String title = resolveEnterTitle(roomId, userId, room);
 
         return new ChatRoomEnterResponse(
                 room.getId(),
@@ -102,6 +107,60 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
         );
     }
 
+
+    /**
+     * 채팅방 진입 응답에서 사용할 title을 room type 정책에 맞춰 결정한다.
+     *
+     * <p>규칙:
+     * <ul>
+     *   <li>DM: 요청 사용자 기준 상대 표시 이름(친구 별칭 > 상대 기본 닉네임 > room title)</li>
+     *   <li>GROUP: 요청 사용자가 설정한 채팅방 커스텀 이름 > room title</li>
+     *   <li>OPEN: room title</li>
+     * </ul>
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 요청 사용자 ID
+     * @param room 채팅방 엔티티
+     * @return room type 정책이 반영된 표시 제목
+     */
+    private String resolveEnterTitle(Long roomId, Long userId, ChatRoom room) {
+        String roomTitle = room.getName() != null ? room.getName() : "";
+
+        return switch (room.getRoomType()) {
+            case DM -> resolveDmTitle(roomId, userId, roomTitle);
+            case GROUP -> resolveGroupTitle(roomId, userId, roomTitle);
+            case OPEN -> roomTitle;
+        };
+    }
+
+    /**
+     * DM 방 title을 계산한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 요청 사용자 ID
+     * @param roomTitle 채팅방 기본 제목
+     * @return DM 표시 제목
+     */
+    private String resolveDmTitle(Long roomId, Long userId, String roomTitle) {
+        Long partnerId = chatRoomQueryService.getMemberId(roomId, userId);
+
+        return userDisplayNameService.resolveDisplayName(partnerId, userId)
+                .orElse(roomTitle);
+    }
+
+    /**
+     * GROUP 방 title을 계산한다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 요청 사용자 ID
+     * @param roomTitle 채팅방 기본 제목
+     * @return GROUP 표시 제목
+     */
+    private String resolveGroupTitle(Long roomId, Long userId, String roomTitle) {
+        Optional<String> customRoomName = chatListService.getCustomRoomName(roomId, userId);
+        // TODO room title이 없으면 캐싱 컬럼을 통해서 본인 제외한 채팅방 멤버 이름으로 room title 하기
+        return customRoomName.orElse(roomTitle);
+    }
     /**
      * 1:1 채팅방을 조회/생성하고 멤버십을 보장한다.
      *

--- a/src/test/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImplTest.java
+++ b/src/test/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImplTest.java
@@ -19,10 +19,12 @@ import com.chat_server.chatroommember.service.ChatRoomMemberService;
 import com.chat_server.common.cursor.ChatMessageCursorCodec;
 import com.chat_server.common.cursor.ChatMessageCursorKey;
 import com.chat_server.user.entity.User;
+import com.chat_server.user.service.UserDisplayNameService;
 import com.chat_server.user.service.UserService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,7 @@ class ChatRoomFacadeServiceImplTest {
     private ChatMessageService chatMessageService;
     private ChatRoomQueryService chatRoomQueryService;
     private UserService userService;
+    private UserDisplayNameService userDisplayNameService;
 
     private ChatRoomFacadeServiceImpl target;
 
@@ -51,6 +54,7 @@ class ChatRoomFacadeServiceImplTest {
         chatMessageService = mock(ChatMessageService.class);
         chatRoomQueryService = mock(ChatRoomQueryService.class);
         userService = mock(UserService.class);
+        userDisplayNameService = mock(UserDisplayNameService.class);
 
         target = new ChatRoomFacadeServiceImpl(
                 chatRoomService,
@@ -58,8 +62,11 @@ class ChatRoomFacadeServiceImplTest {
                 chatRoomMemberService,
                 chatMessageService,
                 chatRoomQueryService,
-                userService
+                userService,
+                userDisplayNameService
         );
+
+        when(chatListService.getCustomRoomName(Mockito.anyLong(), Mockito.anyLong())).thenReturn(Optional.empty());
     }
 
     @Test
@@ -89,6 +96,8 @@ class ChatRoomFacadeServiceImplTest {
         );
 
         when(chatRoomQueryService.getRoomOrThrow(roomId)).thenReturn(room);
+        when(chatRoomQueryService.getMemberId(roomId, userId)).thenReturn(77L);
+        when(userDisplayNameService.resolveDisplayName(77L, userId)).thenReturn(java.util.Optional.of("상대 별칭"));
         when(chatMessageService.getEnterMessagesByCursor(eq(roomId), eq(limit), any(ChatMessageCursorKey.class)))
                 .thenReturn(slice);
 
@@ -102,7 +111,7 @@ class ChatRoomFacadeServiceImplTest {
 
         assertThat(response.roomId()).isEqualTo(roomId);
         assertThat(response.roomType()).isEqualTo("DM");
-        assertThat(response.title()).isEqualTo("테스트방");
+        assertThat(response.title()).isEqualTo("상대 별칭");
         assertThat(response.messages()).extracting(ChatMessageItemResponse::messageId)
                 .containsExactly(10L, 20L);
 
@@ -266,4 +275,102 @@ class ChatRoomFacadeServiceImplTest {
         assertThat(captor.getValue().lastMessageId()).isEqualTo(111L);
         assertThat(captor.getValue().lastMessageAtEpochMillis()).isEqualTo(millis);
     }
+
+    @Test
+    @DisplayName("DM 방은 표시 이름이 없으면 방 제목으로 fallback 한다")
+    void shouldFallbackToRoomTitleWhenDmDisplayNameIsMissing() {
+        Long roomId = 7L;
+        Long userId = 8L;
+
+        ChatRoom room = ChatRoom.builder()
+                .id(roomId)
+                .roomType(RoomType.DM)
+                .name("")
+                .createdBy(User.builder().id(1L).build())
+                .build();
+
+        when(chatRoomQueryService.getRoomOrThrow(roomId)).thenReturn(room);
+        when(chatRoomQueryService.getMemberId(roomId, userId)).thenReturn(88L);
+        when(userDisplayNameService.resolveDisplayName(88L, userId)).thenReturn(java.util.Optional.empty());
+        when(chatMessageService.getEnterMessagesByCursor(eq(roomId), eq(50), Mockito.isNull()))
+                .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 50), false));
+
+        ChatRoomEnterResponse response = target.enterChatRoom(roomId, userId, null, 50);
+
+        assertThat(response.title()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("DM 이 아닌 방은 기존 room.name을 title로 사용한다")
+    void shouldUseRoomNameWhenRoomTypeIsNotDm() {
+        Long roomId = 8L;
+        Long userId = 9L;
+
+        ChatRoom room = ChatRoom.builder()
+                .id(roomId)
+                .roomType(RoomType.GROUP)
+                .name("그룹방")
+                .createdBy(User.builder().id(1L).build())
+                .build();
+
+        when(chatRoomQueryService.getRoomOrThrow(roomId)).thenReturn(room);
+        when(chatMessageService.getEnterMessagesByCursor(eq(roomId), eq(50), Mockito.isNull()))
+                .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 50), false));
+
+        ChatRoomEnterResponse response = target.enterChatRoom(roomId, userId, null, 50);
+
+        assertThat(response.title()).isEqualTo("그룹방");
+        verify(chatListService).getCustomRoomName(roomId, userId);
+        verify(chatRoomQueryService, Mockito.never()).getMemberId(any(), any());
+        verify(userDisplayNameService, Mockito.never()).resolveDisplayName(any(), any());
+    }
+
+    @Test
+    @DisplayName("GROUP 방은 chat list custom name이 있으면 해당 값을 title로 사용한다")
+    void shouldUseCustomNameWhenGroupHasCustomName() {
+        Long roomId = 11L;
+        Long userId = 12L;
+
+        ChatRoom room = ChatRoom.builder()
+                .id(roomId)
+                .roomType(RoomType.GROUP)
+                .name("원래 그룹방 이름")
+                .createdBy(User.builder().id(1L).build())
+                .build();
+
+        when(chatRoomQueryService.getRoomOrThrow(roomId)).thenReturn(room);
+        when(chatListService.getCustomRoomName(roomId, userId)).thenReturn(Optional.of("내가 바꾼 그룹방 이름"));
+        when(chatMessageService.getEnterMessagesByCursor(eq(roomId), eq(50), Mockito.isNull()))
+                .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 50), false));
+
+        ChatRoomEnterResponse response = target.enterChatRoom(roomId, userId, null, 50);
+
+        assertThat(response.title()).isEqualTo("내가 바꾼 그룹방 이름");
+    }
+
+    @Test
+    @DisplayName("OPEN 방은 room title을 그대로 사용한다")
+    void shouldUseRoomTitleWhenOpenRoom() {
+        Long roomId = 13L;
+        Long userId = 14L;
+
+        ChatRoom room = ChatRoom.builder()
+                .id(roomId)
+                .roomType(RoomType.OPEN)
+                .name("오픈 채팅방")
+                .createdBy(User.builder().id(1L).build())
+                .build();
+
+        when(chatRoomQueryService.getRoomOrThrow(roomId)).thenReturn(room);
+        when(chatMessageService.getEnterMessagesByCursor(eq(roomId), eq(50), Mockito.isNull()))
+                .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 50), false));
+
+        ChatRoomEnterResponse response = target.enterChatRoom(roomId, userId, null, 50);
+
+        assertThat(response.title()).isEqualTo("오픈 채팅방");
+        verify(chatListService, Mockito.never()).getCustomRoomName(roomId, userId);
+        verify(chatRoomQueryService, Mockito.never()).getMemberId(any(), any());
+        verify(userDisplayNameService, Mockito.never()).resolveDisplayName(any(), any());
+    }
+
 }


### PR DESCRIPTION
## Motivation

- 채팅방 입장 시 사용자별로 일관된 방 제목을 보여주기 위해 개선

- DM은 상대방 표시 이름을 사용하고, GROUP은 사용자별 커스텀 방 이름을 우선 사용하며, OPEN은 기존 방 제목을 유지

## Description

- ChatListRepository에 findCustomNameByUserIdAndRoomId를 추가

- JPQL 기반으로 비어 있지 않은 커스텀 이름을 Optional<String>으로 반환

- ChatListService에 getCustomRoomName를 노출하고, ChatListServiceImpl에서 해당 저장소 메서드로 위임하도록 구현

- ChatRoomFacadeServiceImpl에 UserDisplayNameService 의존성을 추가하고, 방 타입별 제목 계산 메서드 resolveEnterTitle를 

## 도입

- resolveDmTitle, resolveGroupTitle로 분리해 DM/GROUP 정책을 명확히 적용

- Optional 사용에 맞춰 import 및 wiring을 정리하고, 기존 title 계산 로직을 정책에 맞게 수정

- ChatRoomFacadeServiceImplTest를 보강

- UserDisplayNameService, ChatListService#getCustomRoomName mocking 추가

- DM fallback 케이스 추가

- 비DM 동작 케이스 추가

- GROUP custom name 적용 케이스 추가

- OPEN 동작 케이스 추가

- 기존 next-cursor/정렬 테스트 보정

## Testing
- ChatRoomFacadeServiceImplTest를 실행해 DM/GROUP/OPEN 제목 계산 시나리오를 검증했고 로컬에서 통과

- 프로젝트 전체 테스트(mvn test)를 실행했고, 빌드 및 테스트가 실패 없이 완료