### PR TITLE
feat: 회원가입 중복 확인 및 로그인 타입 적용, 메시지 unread count 정합성 개선

### DIFF
--- a/src/main/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImpl.java
+++ b/src/main/java/com/chat_server/chatroom/service/impl/ChatRoomFacadeServiceImpl.java
@@ -164,11 +164,15 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
                     // Map에 커스텀 닉네임이 있으면 쓰고, 없으면 원래 닉네임(senderNickname) 사용
                     String displayNickname = displayNameCache.getOrDefault(item.senderId(), item.senderNickname());
                     log.info("item id: {}, item type: {}",item.messageId(), item.messageType());
-                    long readCount = memberReadMap.values().stream()
-                            .filter(lastReadId -> lastReadId >= item.messageId())
-                            .count();
-                    int realUnread = Math.max(0, memberIds.size() - (int)readCount);
-                    return toChatMessageResponse(item, roomId, userId, displayNickname, realUnread);
+                    int realUnread = calculateUnreadCount(item, memberIds, memberReadMap);
+
+                    return toChatMessageResponse(
+                            item,
+                            roomId,
+                            userId,
+                            displayNickname,
+                            realUnread
+                    );
                 })
                 .sorted((a, b) -> a.createdAt().equals(b.createdAt())
                         ? Long.compare(a.messageId(), b.messageId())
@@ -268,11 +272,15 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
                     // Map에 커스텀 닉네임이 있으면 쓰고, 없으면 원래 닉네임(senderNickname) 사용
                     String displayNickname = customNameMap.getOrDefault(item.senderId(), item.senderNickname());
                     log.info("item id: {}, item type: {}",item.messageId(), item.messageType());
-                    long readCount = memberReadMap.values().stream()
-                            .filter(lastReadId -> lastReadId >= item.messageId())
-                            .count();
-                    int realUnread = Math.max(0, senderIds.size() - (int)readCount);
-                    return toChatMessageResponse(item, roomId, userId, displayNickname, realUnread);
+                    int realUnread = calculateUnreadCount(item, memberIds, memberReadMap);
+
+                    return toChatMessageResponse(
+                            item,
+                            roomId,
+                            userId,
+                            displayNickname,
+                            realUnread
+                    );
                 })
                 .sorted((a, b) -> a.createdAt().equals(b.createdAt())
                         ? Long.compare(a.messageId(), b.messageId())
@@ -454,46 +462,6 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
                 .toList();
     }
 
-//    @Override
-//    public void inviteMembers(Long roomId, Long inviterId, List<String> inviteeUuids) {
-//        chatRoomQueryService.validateMemberOrThrow(roomId, inviterId);
-//        ChatRoom chatRoom = chatRoomQueryService.getRoomOrThrow(roomId);
-//
-//        chatRoomMemberService.addMembers(roomId,inviteeUuids, chatRoom);
-//
-//        List<User> invitees = userService.getUserIdByUserUuids(inviteeUuids);
-//        List<Long> inviteeIds = invitees.stream().map(User::getId).toList();
-//
-//        chatListService.ensureMembershipsBulk(roomId,inviteeIds);
-//
-//        User inviter = userService.getUserById(inviterId);
-//
-//
-//        Map<String, Object> payload = new HashMap<>();
-//
-//        payload.put("inviter", Map.of(
-//                "uuid",inviter.getUuid(),
-//                "name", inviter.getNickname()
-//        ) );
-//
-//        // 2-2. 피초대자들 정보 리스트 (UUID + 원래 닉네임)
-//        List<Map<String, String>> inviteeInfos = invitees.stream()
-//                .map(u -> Map.of("uuid", u.getUuid(), "name", u.getNickname()))
-//                .toList();
-//        payload.put("invitees", inviteeInfos);
-//
-//        // 3. JSON 문자열로 직렬화 (ObjectMapper 활용)
-//        String content = "";
-//        try {
-//            // 💡 클래스 상단에 private final ObjectMapper objectMapper; 주입 필요
-//            content = objectMapper.writeValueAsString(payload);
-//        } catch (JsonProcessingException e) {
-//            log.error("시스템 초대 메시지 JSON 변환 실패", e);
-//            // 에러 발생 시 Fallback으로 단순 문자열 저장
-//            content = String.format("{\"fallback\": \"%s님이 %d명을 초대했습니다.\"}", inviter.getNickname(), invitees.size());
-//        }
-//        chatMessageFacadeService.saveAndBroadcastSystemMessage(roomId, inviterId, MessageType.SYSTEM_INVITE, content);
-//    }
     @Override
     public void inviteMembers(Long roomId, Long inviterId, List<String> inviteeUuids) {
         // 1. 초대자 권한 검증 및 방 정보 조회
@@ -576,7 +544,7 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
                 .distinct().toList();
         Map<Long, String> displayNameCache = userDisplayNameService.resolveDisplayNamesBulk(userId, senderIds);
 
-        // 3. 안읽음 카운트 처리를 위한 Redis 조회 (세인님의 기존 로직 재사용)
+        // 3. 안읽음 카운트 처리를 위한 Redis 조회
         List<Long> memberIds = chatRoomMemberService.getRoomMemberIdsByRoomId(roomId);
         Map<Long, Long> memberReadMap = chatMetadataRedisService.getAllMembersLastReadId(roomId, memberIds);
 
@@ -652,6 +620,8 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
     ) {
         return toChatMessageResponse(item, roomId, viewerUserId, displayNickname, item.unreadCount());
     }
+
+
     private ChatMessageResponse toChatMessageResponse(
             ChatMessageItemResponse item,
             Long roomId,
@@ -660,11 +630,19 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
             int realUnread
     ) {
         String content = item.content();
-        if(item.messageType().equalsIgnoreCase("SYSTEM_LEAVE")){
+
+        if (item.messageType().equalsIgnoreCase("SYSTEM_LEAVE")) {
             content = displayNickname + content;
         }
 
-        return chatMessageResponseMapper.fromItem(item,roomId,viewerUserId);
+        return chatMessageResponseMapper.fromItem(
+                item,
+                roomId,
+                viewerUserId,
+                displayNickname,
+                content,
+                realUnread
+        );
     }
     private void broadcastChatListUpsertEvents(Long roomId, Set<Long> participantUserIds) {
         for (Long participantUserId : participantUserIds) {
@@ -691,5 +669,23 @@ public class ChatRoomFacadeServiceImpl implements ChatRoomFacadeService {
         }
 
         return trimmed;
+    }
+
+    private int calculateUnreadCount(
+            ChatMessageItemResponse item,
+            List<Long> memberIds,
+            Map<Long, Long> memberReadMap
+    ) {
+        long recipientCount = memberIds.stream()
+                .filter(memberId -> !memberId.equals(item.senderId()))
+                .count();
+
+        long readRecipientCount = memberReadMap.entrySet().stream()
+                .filter(entry -> !entry.getKey().equals(item.senderId()))
+                .filter(entry -> entry.getValue() != null)
+                .filter(entry -> entry.getValue() >= item.messageId())
+                .count();
+
+        return Math.max(0, (int) (recipientCount - readRecipientCount));
     }
 }

--- a/src/main/java/com/chat_server/common/mapper/ChatMessageResponseMapper.java
+++ b/src/main/java/com/chat_server/common/mapper/ChatMessageResponseMapper.java
@@ -67,7 +67,10 @@ public class ChatMessageResponseMapper {
     public ChatMessageResponse fromItem(
             ChatMessageItemResponse item,
             Long roomId,
-            Long viewerUserId
+            Long viewerUserId,
+            String displayNickname,
+            String content,
+            int unread
     ) {
         return new ChatMessageResponse(
                 item.messageId(),
@@ -76,13 +79,13 @@ public class ChatMessageResponseMapper {
                 item.messageType(),
                 new ChatMessageSenderResponse(
                         item.senderUuid(),
-                        item.senderNickname(),
+                        displayNickname,
                         item.profileImageUrl()
                 ),
-                item.content(),
+                content,
                 item.createdAt(),
                 item.senderId().equals(viewerUserId),
-                item.unreadCount()
+                unread
         );
     }
 

--- a/src/main/java/com/chat_server/logintype/entity/LoginType.java
+++ b/src/main/java/com/chat_server/logintype/entity/LoginType.java
@@ -1,0 +1,27 @@
+package com.chat_server.logintype.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "login_type")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/chat_server/logintype/enums/LoginTypeEnum.java
+++ b/src/main/java/com/chat_server/logintype/enums/LoginTypeEnum.java
@@ -1,0 +1,6 @@
+package com.chat_server.logintype.enums;
+
+public enum LoginTypeEnum {
+    LOCAL,
+    OAUTH
+}

--- a/src/main/java/com/chat_server/logintype/repository/LoginTypeRepository.java
+++ b/src/main/java/com/chat_server/logintype/repository/LoginTypeRepository.java
@@ -1,0 +1,10 @@
+package com.chat_server.logintype.repository;
+
+import com.chat_server.logintype.entity.LoginType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LoginTypeRepository extends JpaRepository<LoginType, Integer> {
+    Optional<LoginType> findByName(String name);
+}

--- a/src/main/java/com/chat_server/security/config/SecurityConfig.java
+++ b/src/main/java/com/chat_server/security/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                                         authorizeRequests.requestMatchers(
                                             "/api/v1/users/login",
                                             "/api/v1/users/register",
+                                            "/api/v1/users/input-id/check",
                                             // SockJS/WS 관련 - 전부 허용 (별도 STOMP 인증에서 처리)
                                             "/api/ws/**",
                                             "/api/ws-chat/**",

--- a/src/main/java/com/chat_server/user/controller/UserRegisterController.java
+++ b/src/main/java/com/chat_server/user/controller/UserRegisterController.java
@@ -1,13 +1,15 @@
 package com.chat_server.user.controller;
 
 import com.chat_server.common.dto.response.ApiResponse;
+import com.chat_server.user.dto.request.InputIdCheckRequest;
 import com.chat_server.user.dto.request.UserRegisterRequest;
+import com.chat_server.user.dto.response.InputIdCheckResponse;
 import com.chat_server.user.service.UserFacadeService;
-import com.chat_server.user.service.UserService;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -31,16 +33,19 @@ public class UserRegisterController {
     private final UserFacadeService userFacadeService;
 
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse> register(@Valid @RequestBody UserRegisterRequest registerRequest,
-                                                BindingResult bindingResult) {
-        log.info("controller 시작");
-        log.info("register user : {}", registerRequest);
-        if(bindingResult.hasErrors()) {
-            throw new ValidationException("request validation error");
-        }
-
+    public ResponseEntity<ApiResponse> register(@Valid @RequestBody UserRegisterRequest registerRequest) {
         userFacadeService.signUp(registerRequest);
         log.info("회원가입 처리 완료");
         return ResponseEntity.status(201).body(ApiResponse.success(201));
+    }
+
+    @PostMapping("input-id/check")
+    public ResponseEntity<ApiResponse<InputIdCheckResponse>> checkInputId(
+            @Valid @RequestBody InputIdCheckRequest inputIdCheckRequest
+    ){
+
+        InputIdCheckResponse inputIdCheckResponse = userFacadeService.checkInputIdAvailability(inputIdCheckRequest);
+        ApiResponse<InputIdCheckResponse> response = ApiResponse.success(200, inputIdCheckResponse);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/chat_server/user/dto/request/InputIdCheckRequest.java
+++ b/src/main/java/com/chat_server/user/dto/request/InputIdCheckRequest.java
@@ -1,0 +1,17 @@
+package com.chat_server.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record InputIdCheckRequest(
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(min = 4, max = 30, message = "아이디는 4자 이상 30자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^[a-zA-Z0-9_]+$",
+                message = "아이디는 영문, 숫자, 언더스코어만 사용할 수 있습니다."
+        )
+        String inputId
+) {
+}

--- a/src/main/java/com/chat_server/user/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/chat_server/user/dto/request/UserRegisterRequest.java
@@ -41,8 +41,6 @@ public record UserRegisterRequest(@NotBlank
                                   @NotBlank
                                   String gender,
 
-                                  String email,
-
                                   String  birth,
                                   String phoneNumber
                                   ) {

--- a/src/main/java/com/chat_server/user/dto/response/InputIdCheckResponse.java
+++ b/src/main/java/com/chat_server/user/dto/response/InputIdCheckResponse.java
@@ -1,0 +1,6 @@
+package com.chat_server.user.dto.response;
+
+public record InputIdCheckResponse(
+        boolean available
+) {
+}

--- a/src/main/java/com/chat_server/user/entity/User.java
+++ b/src/main/java/com/chat_server/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.chat_server.user.entity;
 
 import com.chat_server.gender.entity.Gender;
+import com.chat_server.logintype.entity.LoginType;
 import com.chat_server.user.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,15 +30,24 @@ public class User {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
             name = "gender_id",
-            nullable = false,
+            nullable = true,
             foreignKey = @ForeignKey(name = "fk_user_gender")
     )
     private Gender gender;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name= "login_type_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_login_type")
+    )
+    private LoginType loginType;
+
+
     @Column(name = "input_id", nullable = false, length = 30)
     private String inputId;
 
-    @Column(name = "input_password", nullable = false, length = 100)
+    @Column(name = "input_password", nullable = true, length = 100)
     private String inputPassword;
 
     @Column(name = "name", nullable = false, length = 30)
@@ -60,7 +70,7 @@ public class User {
     @Column(name = "login_lasted_at")
     private LocalDateTime loginLastedAt;
 
-    @Column(name= "age", nullable = false)
+    @Column(name= "age", nullable = true)
     private Integer age;
 
 

--- a/src/main/java/com/chat_server/user/service/UserFacadeService.java
+++ b/src/main/java/com/chat_server/user/service/UserFacadeService.java
@@ -1,8 +1,11 @@
 package com.chat_server.user.service;
 
+import com.chat_server.user.dto.request.InputIdCheckRequest;
 import com.chat_server.user.dto.request.UserRegisterRequest;
+import com.chat_server.user.dto.response.InputIdCheckResponse;
 
 public interface UserFacadeService  {
     void signUp(UserRegisterRequest request);
 
+    InputIdCheckResponse checkInputIdAvailability(InputIdCheckRequest inputIdCheckRequest);
 }

--- a/src/main/java/com/chat_server/user/service/UserService.java
+++ b/src/main/java/com/chat_server/user/service/UserService.java
@@ -32,4 +32,6 @@ public interface UserService {
     String getUuidByUserId(Long userId);
 
     User getUserById(Long userId);
+
+    boolean validateUniqueInputId(String inputId);
 }

--- a/src/main/java/com/chat_server/user/service/impl/UserFacadeServiceImpl.java
+++ b/src/main/java/com/chat_server/user/service/impl/UserFacadeServiceImpl.java
@@ -1,6 +1,8 @@
 package com.chat_server.user.service.impl;
 
+import com.chat_server.user.dto.request.InputIdCheckRequest;
 import com.chat_server.user.dto.request.UserRegisterRequest;
+import com.chat_server.user.dto.response.InputIdCheckResponse;
 import com.chat_server.user.service.UserFacadeService;
 import com.chat_server.user.service.UserService;
 import com.chat_server.userprofile.service.UserProfileService;
@@ -28,5 +30,11 @@ public class UserFacadeServiceImpl implements UserFacadeService {
         userProfileService.createUserProfile(userUuid);
         log.info("UserFacadeServiceImpl signUp completed");
 
+    }
+
+    @Override
+    public InputIdCheckResponse checkInputIdAvailability(InputIdCheckRequest inputIdCheckRequest) {
+        String inputId = inputIdCheckRequest.inputId();
+        return new InputIdCheckResponse(userService.validateUniqueInputId(inputId));
     }
 }

--- a/src/main/java/com/chat_server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/chat_server/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,9 @@
 package com.chat_server.user.service.impl;
 
+import com.chat_server.common.dto.exception.NotFoundException;
+import com.chat_server.logintype.entity.LoginType;
+import com.chat_server.logintype.enums.LoginTypeEnum;
+import com.chat_server.logintype.repository.LoginTypeRepository;
 import com.chat_server.security.dto.UserPrincipal;
 import com.chat_server.gender.entity.Gender;
 import com.chat_server.gender.exception.GenderNotFoundException;
@@ -45,6 +49,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final GenderRepository genderRepository;
     private final UserProfileRepository userProfileRepository;
+    private final LoginTypeRepository loginTypeRepository;
 
 
     @Override
@@ -59,6 +64,9 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new GenderNotFoundException("gender not found"));
         String password = passwordEncoder.encode(registerRequest.password());
         String userUuid = UUID.randomUUID().toString();
+        LoginType loginType = loginTypeRepository.findByName(LoginTypeEnum.LOCAL.name())
+                .orElseThrow(NotFoundException::new);
+
         User user = User.builder()
                 .inputId(registerRequest.id())
                 .inputPassword(password)
@@ -67,6 +75,7 @@ public class UserServiceImpl implements UserService {
                 .nickname(registerRequest.nickName())
                 .status(UserStatus.ACTIVE)
                 .gender(gender)
+                .loginType(loginType)
                 .createdAt(LocalDateTime.now())
                 .uuid(userUuid)
                 .build();
@@ -112,6 +121,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public User getUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    }
+
+    @Override
+    public boolean validateUniqueInputId(String inputId) {
+        return !userRepository.existsByInputId(inputId);
     }
 
 

--- a/src/main/resources/script/ddl.sql
+++ b/src/main/resources/script/ddl.sql
@@ -71,26 +71,37 @@ create table if not exists gender
 create index idx_gender_name
     on gender (name);
 
+create table if not exists login_type(
+  id        int auto_increment,
+  name      varchar(15) not null,
+created_at  datetime    default CURRENT_TIMESTAMP not null,
+    constraint pk_login_type primary key (id)
+);
+
 create table if not exists user
 (
     id              bigint auto_increment
         primary key,
-    gender_id       int                                   not null,
+    gender_id       int                                   null,
+    login_type_id   int                                   not null DEFAULT 1,
     input_id        varchar(30)                           not null,
-    input_password  varchar(100)                          not null,
-    age             int                                   not null,
+    input_password  varchar(100)                          null,
+    age             int                                   null,
     name            varchar(30)                           not null,
     nickname        varchar(30)                           not null,
     uuid            varchar(36)                           not null,
     status          varchar(20) default 'ACTIVE'          not null,
     created_at      datetime    default CURRENT_TIMESTAMP not null,
     login_lasted_at datetime                              null,
+
     constraint uk_user_input_id
         unique (input_id),
     constraint uk_user_uuid
         unique (uuid),
     constraint fk_user_gender
-        foreign key (gender_id) references gender (id)
+        foreign key (gender_id) references gender (id),
+    constraint fk_user_login_type
+        foreign key (login_type_id) references login_type(id)
 );
 
 create table if not exists chat_message

--- a/src/main/resources/script/ddl.sql
+++ b/src/main/resources/script/ddl.sql
@@ -413,3 +413,21 @@ create table if not exists user_profile_image
 create index idx_user_profile_image_current
     on user_profile_image (user_profile_id, is_current);
 
+CREATE TABLE if not exists oauth_account (
+                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               user_id BIGINT NOT NULL,
+                               provider VARCHAR(30) NOT NULL,
+                               provider_user_id VARCHAR(100) NOT NULL,
+                               email VARCHAR(255) NULL,
+                               nickname VARCHAR(100) NULL,
+                               profile_image_url VARCHAR(500) NULL,
+                               created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                               updated_at DATETIME NULL,
+
+                               CONSTRAINT fk_oauth_account_user
+                                   FOREIGN KEY (user_id) REFERENCES user(id)
+                                       ON DELETE CASCADE,
+
+                               CONSTRAINT uk_oauth_provider_user
+                                   UNIQUE (provider, provider_user_id)
+);

--- a/src/main/resources/script/dml.sql
+++ b/src/main/resources/script/dml.sql
@@ -2,7 +2,8 @@
 
 insert into `gender` (`name`) values('남자');
 insert into `gender` (`name`) values('여자');
-
+insert login_type(`name`) values ("LOCAL");
+insert login_type(`name`) values("OAUTH");
 #
 # -- 임시 데이터
 # INSERT INTO `user`


### PR DESCRIPTION
# PR 제목

feat: 회원가입 중복 확인 및 로그인 타입 적용, 메시지 unread count 정합성 개선

---

## 작업 개요

회원가입 기능 보완 과정에서 아이디 중복 확인 API와 로그인 타입 관리 구조를 추가하고, 일반 회원가입 시 `LOCAL` 로그인 타입이 명시적으로 저장되도록 개선했습니다.

또한 채팅방 내부 메시지의 unread count 계산에서 메시지 발신자까지 미읽음 대상에 포함되는 문제가 있어, 발신자를 제외한 실제 수신자 기준으로 unread count를 계산하도록 수정했습니다.

이번 작업은 회원가입 정합성, 로그인 타입 구분, 메시지 읽음 상태 표시 정확도를 개선하는 데 목적이 있습니다.

---

## 주요 변경 사항

### 1. 아이디 중복 확인 API 추가

회원가입 전에 사용자가 입력한 `inputId`를 사용할 수 있는지 확인할 수 있도록 중복 확인 API를 추가했습니다.

- `InputIdCheckRequest` 추가
- `InputIdCheckResponse` 추가
- `POST /api/v1/users/input-id/check` API 추가
- Spring Security 허용 경로에 중복 확인 API 추가
- `UserRepository.existsByInputId()` 기반으로 사용 가능 여부 반환

응답 기준은 다음과 같습니다.

```text
available = true  → 사용 가능한 아이디
available = false → 이미 사용 중인 아이디
```

---

### 2. 회원가입 요청 검증 방식 정리

기존에는 Controller에서 `BindingResult`를 직접 확인하고 `ValidationException`을 던졌지만, 이번 작업에서는 `@Valid` 기반 검증 흐름을 사용하도록 정리했습니다.

이를 통해 Controller의 책임을 줄이고, request validation 실패 처리를 Spring Validation 흐름에 맞게 가져갈 수 있도록 했습니다.

---

### 3. 로그인 타입 테이블 및 엔티티 추가

일반 로그인 사용자와 OAuth 사용자를 구분하기 위해 `login_type` 테이블과 관련 엔티티를 추가했습니다.

추가된 구조는 다음과 같습니다.

- `LoginType` 엔티티 추가
- `LoginTypeEnum` 추가
- `LoginTypeRepository` 추가
- `user.login_type_id` 컬럼 추가
- `login_type` 초기 데이터 추가
  - `LOCAL`
  - `OAUTH`

일반 회원가입 시에는 `LOCAL` 타입을 조회하여 `User`에 명시적으로 설정하도록 수정했습니다.

---

### 4. User 엔티티 구조 변경

OAuth 사용자까지 수용할 수 있도록 일부 필드의 nullable 정책을 조정했습니다.

변경 사항은 다음과 같습니다.

- `gender_id` nullable 허용
- `input_password` nullable 허용
- `age` nullable 허용
- `login_type_id` 추가
- `LoginType` 연관관계 추가

일반 회원가입 사용자는 여전히 request validation과 service 로직에서 필수값을 검증하며, OAuth 사용자는 별도 흐름에서 필요한 값만 저장할 수 있도록 구조를 확장했습니다.

---

### 5. 일반 회원가입 시 loginType 명시 저장

DB 컬럼에 default 값을 설정해도 JPA가 insert 시 null 값을 명시하면 DB default가 적용되지 않는 문제가 있었습니다.

이를 해결하기 위해 일반 회원가입 시 `LoginTypeEnum.LOCAL`에 해당하는 `LoginType`을 조회한 뒤, `User` 생성 시 명시적으로 설정하도록 수정했습니다.

```text
회원가입 요청
→ LOCAL 로그인 타입 조회
→ User.loginType에 명시 설정
→ User 저장
```

---

### 6. 메시지 unread count 계산 정합성 개선

채팅방 내부 메시지의 unread count 계산에서 기존에는 전체 멤버 수를 기준으로 계산하고 있었습니다.

기존 방식은 다음과 같은 문제가 있었습니다.

```text
전체 멤버 수 - 읽은 사람 수
```

이 경우 메시지를 보낸 사람도 미읽음 대상에 포함될 수 있어, 실제로는 상대방이 읽었는데도 unread count가 남아 보이는 문제가 발생했습니다.

이를 해결하기 위해 메시지 unread count 계산 기준을 다음과 같이 변경했습니다.

```text
발신자를 제외한 수신자 수 - 발신자를 제외한 읽은 수신자 수
```

즉, 메시지 발신자는 unread 대상에서 제외하고, 실제 수신자 기준으로만 unread count를 계산하도록 수정했습니다.

---

### 7. 메시지 응답 매핑 개선

`ChatMessageResponseMapper.fromItem()`에서 계산된 unread count와 수신자 기준 표시 이름이 실제 응답에 반영되도록 수정했습니다.

기존에는 서비스에서 `realUnread`를 계산하더라도 mapper에서 `item.unreadCount()`를 그대로 사용하는 문제가 있었습니다.

수정 후에는 다음 값을 명시적으로 응답에 반영합니다.

- 수신자 기준 displayNickname
- SYSTEM_LEAVE 메시지 content 보정
- 계산된 realUnread count

---

### 8. 불필요한 주석 코드 정리

`ChatRoomFacadeServiceImpl`에 남아 있던 이전 초대 처리 주석 코드를 제거하여 코드 가독성을 개선했습니다.

---

## 변경된 주요 파일

- `ChatRoomFacadeServiceImpl`
- `ChatMessageResponseMapper`
- `SecurityConfig`
- `UserRegisterController`
- `InputIdCheckRequest`
- `InputIdCheckResponse`
- `User`
- `UserFacadeService`
- `UserFacadeServiceImpl`
- `UserService`
- `UserServiceImpl`
- `LoginType`
- `LoginTypeEnum`
- `LoginTypeRepository`
- DB 초기화 SQL

---

## 검증 내용

### 회원가입 관련

- 신규 아이디 중복 확인 시 `available = true` 반환 확인
- 이미 존재하는 아이디 중복 확인 시 `available = false` 반환 확인
- 중복 확인 API가 SecurityConfig에서 인증 없이 접근 가능한지 확인
- 일반 회원가입 시 `login_type_id`가 `LOCAL`로 정상 저장되는지 확인
- 회원가입 시 `user_profile` 생성 흐름에 영향이 없는지 확인

### 메시지 unread count 관련

- 1:1 채팅방에서 상대방이 메시지를 읽었을 때 unread count가 0으로 계산되는지 확인
- 메시지 발신자가 unread 대상에 포함되지 않는지 확인
- 채팅방 최초 진입 시 Redis 기반 read 상태가 메시지 응답 unread count에 반영되는지 확인
- 추가 메시지 조회 시에도 동일한 unread count 계산 기준이 적용되는지 확인

---

## 기대 효과

- 회원가입 전 아이디 중복 여부를 프론트에서 명확히 확인할 수 있습니다.
- 일반 로그인 사용자와 OAuth 사용자를 login type 기준으로 구분할 수 있습니다.
- JPA insert 시 DB default에 의존하지 않고 애플리케이션 코드에서 로그인 타입을 명시적으로 관리할 수 있습니다.
- 채팅방 내부 메시지 unread count가 실제 수신자 기준으로 계산되어 읽음 표시 정합성이 개선됩니다.
- 수신자 기준 표시 이름과 계산된 unread count가 응답 DTO에 정확히 반영됩니다.

---

## 체크리스트

- [x] 아이디 중복 확인 API 추가
- [x] 회원가입 request validation 흐름 정리
- [x] login_type 테이블 및 엔티티 추가
- [x] 일반 회원가입 시 LOCAL 로그인 타입 저장
- [x] OAuth 사용자를 고려한 User nullable 정책 조정
- [x] 메시지 unread count 계산식 수정
- [x] 메시지 응답 mapper에 계산된 unread count 반영
- [x] SecurityConfig 허용 경로 추가
- [x] 불필요한 주석 코드 정리

---

## 추가 확인 사항

`UserRegisterController`의 중복 확인 매핑은 현재 다음처럼 되어 있다면:

```java
@PostMapping("input-id/check")
```

아래처럼 `/`를 붙이는 것이 더 명확합니다.

```java
@PostMapping("/input-id/check")
```