### PR TITLE
feat: 친구코드 기반 사용자 검색 및 프로필 응답 구조 개선

### DIFF
--- a/src/main/java/com/chat_server/friend/repository/FriendRepository.java
+++ b/src/main/java/com/chat_server/friend/repository/FriendRepository.java
@@ -37,4 +37,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long>, FriendRep
             @Param("userId") Long userId,
             @Param("friendUserIds") List<Long> friendUserIds
     );
+
+    boolean existsByUser_IdAndFriendUser_Id(Long userId, Long friendUserId);
 }

--- a/src/main/java/com/chat_server/friend/service/impl/FriendServiceImpl.java
+++ b/src/main/java/com/chat_server/friend/service/impl/FriendServiceImpl.java
@@ -1,6 +1,8 @@
 package com.chat_server.friend.service.impl;
 
 import com.chat_server.common.cursor.CursorCodec;
+import com.chat_server.common.dto.exception.ConflictException;
+import com.chat_server.common.dto.exception.ValidationException;
 import com.chat_server.friend.dto.request.UserFriendRegisterRequest;
 import com.chat_server.friend.dto.response.CursorPageResponse;
 import com.chat_server.common.cursor.CursorKey;
@@ -33,38 +35,24 @@ public class FriendServiceImpl implements FriendService {
     @Override
     @Transactional(readOnly = true)
     public CursorPageResponse<UserFriendResponse> getFriendsByCursor(Long userId, int limit, @Nullable String cursor) {
-        log.info("friend service start");
         if (limit <= 0 || limit > 200) {
-            log.info("limit 가드레일");
             limit = 50;
-        }// 가드레일
-
-        log.info("decoded before");
-        CursorKey decoded = CursorCodec.decode(cursor);
-        log.info("decoded after");
-        log.info("repository before");
-        Slice<UserFriendResponse> slice = friendRepository.getFriendsWithProfileByCursor(userId, limit, decoded);
-        log.info("repository after");
-        // next 선언
-        String next = null;
-        log.info("next null ");
-        if (slice.hasNext() && !slice.getContent().isEmpty()) {
-            log.info("slice ");
-            UserFriendResponse last = slice.getContent().get(slice.getContent().size() - 1);
-            next = CursorCodec.encode(last.nickName().toLowerCase(Locale.ROOT), last.uuid());
-            log.info("next: {}",next);
         }
 
-        log.info("return ");
+        CursorKey decoded = CursorCodec.decode(cursor);
+
+        Slice<UserFriendResponse> slice = friendRepository.getFriendsWithProfileByCursor(userId, limit, decoded);
+        String next = null;
+        if (slice.hasNext() && !slice.getContent().isEmpty()) {
+            UserFriendResponse last = slice.getContent().get(slice.getContent().size() - 1);
+            next = CursorCodec.encode(last.nickName().toLowerCase(Locale.ROOT), last.uuid());
+        }
         return new CursorPageResponse<>(slice.getContent(), next, slice.hasNext());
     }
 
     @Override
     public void saveFriend(UserFriendRegisterRequest registerRequest, Long userId) {
-
         String friendId = registerRequest.friendId();
-        log.info("friend id: {}", friendId);
-        log.info("friend id: {}", userId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
@@ -73,6 +61,14 @@ public class FriendServiceImpl implements FriendService {
         // todo 검색 방법에 대해서도 고민을 해봐야할듯
         User friend = userRepository.findByUuid(friendId)
                 .orElseThrow(UserNotFoundException::new);
+
+        if (user.getId().equals(friend.getId())) {
+            throw new ValidationException("자기 자신은 친구로 추가할 수 없습니다.");
+        }
+
+        if (friendRepository.existsByUser_IdAndFriendUser_Id(user.getId(), friend.getId())) {
+            throw new ConflictException("이미 친구로 추가된 사용자입니다.");
+        }
 
         Friend registerFriend = Friend.builder()
                 .user(user)

--- a/src/main/java/com/chat_server/search/controller/SearchController.java
+++ b/src/main/java/com/chat_server/search/controller/SearchController.java
@@ -5,6 +5,7 @@ import com.chat_server.search.dto.request.SearchUserRequest;
 import com.chat_server.search.dto.response.SearchUserResponse;
 import com.chat_server.search.service.SearchService;
 import com.chat_server.user.dto.response.AuthenticatedUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -28,12 +29,12 @@ public class SearchController {
     @PostMapping("/users")
     public ResponseEntity<ApiResponse<SearchUserResponse>> searchUser(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-        @RequestBody SearchUserRequest request
+        @Valid @RequestBody SearchUserRequest request
     ){
         log.info("search controller");
-        log.info("id : {}", request.userId());
+        log.info("id : {}", request.keyword());
         Long userId = authenticatedUser.userId();
-        SearchUserResponse searchUserResponse = searchService.searchUserByUserId(userId, request);
+        SearchUserResponse searchUserResponse = searchService.searchUser(userId, request);
         log.info("search response: {}", searchUserResponse);
         ApiResponse<SearchUserResponse> response = ApiResponse.success(200, "검색에 성공했습니다.",searchUserResponse);
         log.info("response : {}", response.getData());

--- a/src/main/java/com/chat_server/search/dto/request/SearchUserRequest.java
+++ b/src/main/java/com/chat_server/search/dto/request/SearchUserRequest.java
@@ -1,11 +1,13 @@
 package com.chat_server.search.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SearchUserRequest(
-    @NotBlank
-        @Size(min = 1, max = 25)
-    String userId) {
-
+        @JsonAlias({"userId", "friendCode"})
+        @NotBlank(message = "검색어는 필수입니다.")
+        @Size(min = 1, max = 30, message = "검색어는 1자 이상 30자 이하로 입력해주세요.")
+        String keyword
+) {
 }

--- a/src/main/java/com/chat_server/search/dto/response/SearchUserResponse.java
+++ b/src/main/java/com/chat_server/search/dto/response/SearchUserResponse.java
@@ -1,9 +1,11 @@
 package com.chat_server.search.dto.response;
 
-public record SearchUserResponse(String uuid,
-                                 String name,
-                                 String profileUrl,
-                                 boolean isFriend
+public record SearchUserResponse(
+        String uuid,
+        String name,
+        String friendCode,
+        String profileUrl,
+        boolean isFriend,
+        boolean isMe
 ) {
-
 }

--- a/src/main/java/com/chat_server/search/service/SearchService.java
+++ b/src/main/java/com/chat_server/search/service/SearchService.java
@@ -6,5 +6,5 @@ import com.chat_server.search.dto.response.SearchUserResponse;
 import java.util.List;
 
 public interface SearchService {
-    SearchUserResponse searchUserByUserId(Long userId,SearchUserRequest request);
+    SearchUserResponse searchUser(Long userId,SearchUserRequest request);
 }

--- a/src/main/java/com/chat_server/search/service/impl/SearchServiceImpl.java
+++ b/src/main/java/com/chat_server/search/service/impl/SearchServiceImpl.java
@@ -12,19 +12,48 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
-
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
-    // todo 추 후 정책이 생기면 별도로 User에 차단, 비활성 등등의 공통 서비스 만들어야함
     private final UserRepository userRepository;
 
-    // null이 아닌 빈 리스트 반환
     @Override
     @Transactional(readOnly = true)
-    public SearchUserResponse searchUserByUserId(Long userId, SearchUserRequest request) {
-         return userRepository.getSearchUserByUserId(userId, request.userId());
+    public SearchUserResponse searchUser(Long userId, SearchUserRequest request) {
+        String keyword = normalizeSearchKeyword(request.keyword());
+
+        SearchUserResponse response = userRepository.searchUserByFriendCodeOrInputId(userId, keyword);
+
+        if (response == null) {
+            throw new UserNotFoundException("사용자를 찾을 수 없습니다.");
+        }
+
+        return response;
+    }
+
+    private String normalizeSearchKeyword(String keyword) {
+        if (keyword == null) {
+            return "";
+        }
+
+        String trimmed = keyword.trim();
+
+        if (trimmed.isBlank()) {
+            return "";
+        }
+
+        String compact = trimmed
+                .replace(" ", "")
+                .replace("-", "")
+                .toUpperCase();
+
+        if (compact.startsWith("CTK")) {
+            String codeBody = compact.substring(3);
+            return "CTK-" + codeBody;
+        }
+
+        return trimmed;
     }
 }

--- a/src/main/java/com/chat_server/search/service/impl/SearchServiceImpl.java
+++ b/src/main/java/com/chat_server/search/service/impl/SearchServiceImpl.java
@@ -10,13 +10,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
+
+    private static final String FRIEND_CODE_PREFIX = "CTK-";
+    private static final int FRIEND_CODE_BODY_LENGTH = 8;
+    private static final String FRIEND_CODE_BODY_PATTERN = "^[A-Z0-9]{8}$";
+
     private final UserRepository userRepository;
 
     @Override
@@ -49,11 +52,25 @@ public class SearchServiceImpl implements SearchService {
                 .replace("-", "")
                 .toUpperCase();
 
-        if (compact.startsWith("CTK")) {
-            String codeBody = compact.substring(3);
-            return "CTK-" + codeBody;
+        if (isFriendCodeLike(compact)) {
+            return FRIEND_CODE_PREFIX + compact.substring(3);
         }
 
         return trimmed;
+    }
+
+    private boolean isFriendCodeLike(String compactKeyword) {
+        if (compactKeyword == null) {
+            return false;
+        }
+
+        if (!compactKeyword.startsWith("CTK")) {
+            return false;
+        }
+
+        String body = compactKeyword.substring(3);
+
+        return body.length() == FRIEND_CODE_BODY_LENGTH
+                && body.matches(FRIEND_CODE_BODY_PATTERN);
     }
 }

--- a/src/main/java/com/chat_server/user/entity/User.java
+++ b/src/main/java/com/chat_server/user/entity/User.java
@@ -15,7 +15,8 @@ import java.time.LocalDateTime;
         name = "user",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_user_input_id", columnNames = "input_id"),
-                @UniqueConstraint(name = "uk_user_uuid", columnNames = "uuid")
+                @UniqueConstraint(name = "uk_user_uuid", columnNames = "uuid"),
+                @UniqueConstraint(name = "uk_user_friend_code", columnNames = "friend_code")
         }
 )
 @Builder
@@ -58,6 +59,9 @@ public class User {
 
     @Column(name = "uuid", nullable = false, length = 36)
     private String uuid;
+
+    @Column(name = "friend_code", nullable = false, length = 20)
+    private String friendCode;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)

--- a/src/main/java/com/chat_server/user/repository/UserRepository.java
+++ b/src/main/java/com/chat_server/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     boolean existsByInputId(String inputId);
 
     List<User> findAllByUuidIn(List<String> uuids);
+
+    boolean existsByFriendCode(String friendCode);
 }

--- a/src/main/java/com/chat_server/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/chat_server/user/repository/UserRepositoryCustom.java
@@ -23,6 +23,7 @@ public interface UserRepositoryCustom {
     Optional<AuthenticatedUser> authorizeUserByUserId(String userId, String roleName);
     SearchUserResponse getSearchUserByUserId(Long userId, String searchUserId);
     Optional<Long> getUserIdByUserUuid(String userUuid);
-    Optional<String> resolveUserDisplayName(Long viewerId, Long targetId);
+    SearchUserResponse searchUserByFriendCodeOrInputId(Long viewerUserId, String keyword);
+
 }
 

--- a/src/main/java/com/chat_server/user/repository/impl/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/chat_server/user/repository/impl/UserRepositoryCustomImpl.java
@@ -107,16 +107,36 @@ public class UserRepositoryCustomImpl extends QuerydslRepositorySupport implemen
         );
     }
 
+
     @Override
-    public Optional<String> resolveUserDisplayName(Long viewerId, Long targetId) {
-        return Optional.empty();
-//        return Optional.ofNullable(
-//            from(qUser)
-//                .leftJoin(qFriend).on(qFriend.user.id.eq(viewerId).and(qFriend.friend.id.eq(targetId)))
-//                .select(q)
-//                .where(qUser.id.eq(viewerId).and(qFriend.friend.id.eq(targetId)))
-//                .fetchOne()
-//        );
+    public SearchUserResponse searchUserByFriendCodeOrInputId(Long viewerUserId, String keyword) {
+        return from(qUser)
+                .select(Projections.constructor(
+                        SearchUserResponse.class,
+                        qUser.uuid,
+                        qUser.nickname,
+                        qUser.friendCode,
+                        qUserProfileImage.imageUrl,
+                        qFriend.id.isNotNull(),
+                        qUser.id.eq(viewerUserId)
+                ))
+                .innerJoin(qUserProfile).on(qUserProfile.user.eq(qUser))
+                .leftJoin(qUserProfileImage).on(
+                        qUserProfileImage.userProfile.eq(qUserProfile)
+                                .and(qUserProfileImage.current.isTrue())
+                )
+                .leftJoin(qFriend).on(
+                        qFriend.user.id.eq(viewerUserId)
+                                .and(qFriend.friendUser.eq(qUser))
+                )
+                .where(
+                        qUser.status.eq(UserStatus.ACTIVE)
+                                .and(
+                                        qUser.friendCode.eq(keyword)
+                                                .or(qUser.inputId.eq(keyword))
+                                )
+                )
+                .fetchOne();
     }
 
 

--- a/src/main/java/com/chat_server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/chat_server/user/service/impl/UserServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -45,6 +46,13 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+    private static final String FRIEND_CODE_PREFIX = "CTK-";
+    private static final String FRIEND_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int FRIEND_CODE_RANDOM_LENGTH = 8;
+    private static final int FRIEND_CODE_MAX_RETRY = 10;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final GenderRepository genderRepository;
@@ -73,6 +81,7 @@ public class UserServiceImpl implements UserService {
                 .age(registerRequest.age())
                 .name(registerRequest.name())
                 .nickname(registerRequest.nickName())
+                .friendCode(generateUniqueFriendCode())
                 .status(UserStatus.ACTIVE)
                 .gender(gender)
                 .loginType(loginType)
@@ -128,5 +137,27 @@ public class UserServiceImpl implements UserService {
         return !userRepository.existsByInputId(inputId);
     }
 
+    private String generateUniqueFriendCode() {
+        for (int i = 0; i < FRIEND_CODE_MAX_RETRY; i++) {
+            String friendCode = generateFriendCode();
+
+            if (!userRepository.existsByFriendCode(friendCode)) {
+                return friendCode;
+            }
+        }
+
+        throw new IllegalStateException("친구 코드를 생성하지 못했습니다.");
+    }
+
+    private String generateFriendCode() {
+        StringBuilder builder = new StringBuilder(FRIEND_CODE_PREFIX);
+
+        for (int i = 0; i < FRIEND_CODE_RANDOM_LENGTH; i++) {
+            int index = secureRandom.nextInt(FRIEND_CODE_CHARS.length());
+            builder.append(FRIEND_CODE_CHARS.charAt(index));
+        }
+
+        return builder.toString();
+    }
 
 }

--- a/src/main/java/com/chat_server/userprofile/controller/UserProfileController.java
+++ b/src/main/java/com/chat_server/userprofile/controller/UserProfileController.java
@@ -3,7 +3,7 @@ package com.chat_server.userprofile.controller;
 import com.chat_server.common.dto.response.ApiResponse;
 import com.chat_server.user.dto.response.AuthenticatedUser;
 import com.chat_server.userprofile.dto.request.UserProfileUpdateRequest;
-import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.userprofile.dto.response.UserProfileDetailResponse;
 import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import com.chat_server.userprofile.dto.response.UserProfileUpdateImageResponse;
 import com.chat_server.userprofile.dto.response.UserProfileUpdateResponse;
@@ -24,97 +24,97 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
-
     private final UserProfileFacade userProfileFacade;
 
     /**
-     * 로그인한 유저의 본인 프로필 모든 정보
-     * @param authenticatedUser
-     * @return
+     * 로그인한 유저의 본인 프로필 요약 정보
      */
-    @GetMapping("me/profile/summary")
+    @GetMapping("/me/profile/summary")
     public ResponseEntity<ApiResponse<UserMyProfileSummaryResponse>> getMyProfileSummary(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
-    ){
+    ) {
         log.info("getMyProfileSummary");
+
         Long userId = authenticatedUser.userId();
-        UserMyProfileSummaryResponse userProfileDetailResponse = userProfileService.getMyProfileSummary(userId);
-        ApiResponse<UserMyProfileSummaryResponse> response = ApiResponse.success(200,"profile 성공적 반환",userProfileDetailResponse);
-        log.info("end");
-        return ResponseEntity.ok(response);
+        UserMyProfileSummaryResponse responseData = userProfileService.getMyProfileSummary(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "profile 성공적 반환", responseData)
+        );
     }
 
-
-
     /**
-     * 로그인한 유저의 본인 프로필 모든 정보
-     * @param authenticatedUser
-     * @return
+     * 로그인한 유저의 본인 프로필 상세 정보
      */
-    @GetMapping("me/profile/detail")
-    public ResponseEntity<ApiResponse<UserMyProfileDetailResponse>> getMyProfileDetail(
+    @GetMapping("/me/profile/detail")
+    public ResponseEntity<ApiResponse<UserProfileDetailResponse>> getMyProfileDetail(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
-    ){
+    ) {
         log.info("getMyProfileDetail");
 
         Long userId = authenticatedUser.userId();
-        UserMyProfileDetailResponse userProfileDetailResponse = userProfileService.getMyProfileDetail(userId);
-        ApiResponse<UserMyProfileDetailResponse> response = ApiResponse.success(200,"profile 성공적 반환",userProfileDetailResponse);
-        log.info("end");
-        return ResponseEntity.ok(response);
+        UserProfileDetailResponse responseData = userProfileService.getMyProfileDetail(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "profile 성공적 반환", responseData)
+        );
     }
 
-
     /**
-     * 다른 사람의 프로필 상세 정보
-     * @param userId user 식별키(uuid)
-     * @return
+     * uuid 기반 프로필 상세 정보 조회
+     * - 친구 목록 프로필 클릭
+     * - 채팅방 메시지 프로필 클릭
+     * - 검색 결과 프로필 클릭
      */
-    @GetMapping("{userId}/profile/detail")
-    public ResponseEntity<ApiResponse<UserMyProfileDetailResponse>> getMyProfileDetail(
-            @PathVariable(name = "userId")  String userId
-    ){
-        log.info("getMyProfileDetail");
-        log.info("userId: " + userId);
+    @GetMapping("/profile/{userUuid}")
+    public ResponseEntity<ApiResponse<UserProfileDetailResponse>> getProfileDetailByUuid(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @PathVariable String userUuid
+    ) {
+        log.info("getProfileDetailByUuid userUuid={}", userUuid);
 
-        UserMyProfileDetailResponse userProfileDetailResponse = userProfileService.getMyProfileDetail(userId);
-        ApiResponse<UserMyProfileDetailResponse> response = ApiResponse.success(200,"다른 사람 프로필 상세 정보 반환 완료", userProfileDetailResponse);
+        Long viewerId = authenticatedUser.userId();
 
-        log.info("end");
-        return ResponseEntity.ok(response);
+        UserProfileDetailResponse responseData =
+                userProfileService.getProfileDetailByUuid(viewerId, userUuid);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "프로필 상세 정보 반환 완료", responseData)
+        );
     }
 
     @PostMapping(
-        value = "me/profile/image",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+            value = "/me/profile/image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<ApiResponse<UserProfileUpdateImageResponse>> updateMyProfileImage(
-        @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-        @RequestPart(value = "file") MultipartFile file
-    ){
-        log.info("updateMyProfile");
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestPart(value = "file") MultipartFile file
+    ) {
+        log.info("updateMyProfileImage");
+
         Long userId = authenticatedUser.userId();
-        log.info("file: {}", file);
-        UserProfileUpdateImageResponse userProfileUpdateResponse = userProfileFacade.updateMyProfileImage(userId, file);
-        log.info("user profile facade end");
-        // todo update 시 캐싱된 정보를 최신화 해야하기 때문에 response 반환해줘야함.
-        ApiResponse<UserProfileUpdateImageResponse> response = ApiResponse.success(201, "update 완료",userProfileUpdateResponse);
-        log.info("end");
-        return ResponseEntity.ok(response);
+        UserProfileUpdateImageResponse responseData =
+                userProfileFacade.updateMyProfileImage(userId, file);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(201, "update 완료", responseData)
+        );
     }
 
-    @PostMapping("me/profile")
+    @PostMapping("/me/profile")
     public ResponseEntity<ApiResponse<UserProfileUpdateResponse>> updateMyProfile(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestBody UserProfileUpdateRequest request
-    ){
+    ) {
         log.info("updateMyProfile");
-        Long userId = authenticatedUser.userId();
-        log.info("userId : {}", userId);
-        UserProfileUpdateResponse userProfileUpdateResponse = userProfileFacade.updateMyProfile(userId, request);
-        ApiResponse<UserProfileUpdateResponse> response = ApiResponse.success(200,"수정 완료",userProfileUpdateResponse);
-        log.info("end");
-        return ResponseEntity.ok(response);
-    }
 
+        Long userId = authenticatedUser.userId();
+        UserProfileUpdateResponse responseData =
+                userProfileFacade.updateMyProfile(userId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(200, "수정 완료", responseData)
+        );
+    }
 }

--- a/src/main/java/com/chat_server/userprofile/dto/response/UserMyProfileDetailResponse.java
+++ b/src/main/java/com/chat_server/userprofile/dto/response/UserMyProfileDetailResponse.java
@@ -1,5 +1,11 @@
 package com.chat_server.userprofile.dto.response;
 
 // 프로필 모든 정보 가지고 오는 DTO
-public record UserMyProfileDetailResponse(String nickName, String message, String profileUrl) {
+public record UserMyProfileDetailResponse(
+        String uuid,
+        String nickName,
+        String friendCode,
+        String message,
+        String profileUrl
+) {
 }

--- a/src/main/java/com/chat_server/userprofile/dto/response/UserMyProfileSummaryResponse.java
+++ b/src/main/java/com/chat_server/userprofile/dto/response/UserMyProfileSummaryResponse.java
@@ -3,6 +3,7 @@ package com.chat_server.userprofile.dto.response;
 // 본인 프로필
 public record UserMyProfileSummaryResponse(String uuid,
                                            String nickName,
+                                           String friendCode,
                                            String message,
                                            String profileUrl) {
 

--- a/src/main/java/com/chat_server/userprofile/dto/response/UserProfileDetailResponse.java
+++ b/src/main/java/com/chat_server/userprofile/dto/response/UserProfileDetailResponse.java
@@ -1,11 +1,13 @@
 package com.chat_server.userprofile.dto.response;
 
 // 프로필 모든 정보 가지고 오는 DTO
-public record UserMyProfileDetailResponse(
+public record UserProfileDetailResponse(
         String uuid,
         String nickName,
         String friendCode,
         String message,
-        String profileUrl
+        String profileUrl,
+        boolean friend,
+        boolean me
 ) {
 }

--- a/src/main/java/com/chat_server/userprofile/repository/UserProfileRepository.java
+++ b/src/main/java/com/chat_server/userprofile/repository/UserProfileRepository.java
@@ -3,7 +3,6 @@ package com.chat_server.userprofile.repository;
 import com.chat_server.userprofile.enrtity.UserProfile;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long>, UserProfileRepositoryCustom {
 

--- a/src/main/java/com/chat_server/userprofile/repository/UserProfileRepositoryCustom.java
+++ b/src/main/java/com/chat_server/userprofile/repository/UserProfileRepositoryCustom.java
@@ -3,10 +3,11 @@ package com.chat_server.userprofile.repository;
 import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import java.util.Optional;
 
-import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.userprofile.dto.response.UserProfileDetailResponse;
 
 public interface UserProfileRepositoryCustom {
     Optional<UserMyProfileSummaryResponse> findMyProfile(Long id);
-    Optional<UserMyProfileDetailResponse> findProfileDetail(Long id);
+    Optional<UserProfileDetailResponse> findProfileDetail(Long id);
+    Optional<UserProfileDetailResponse> findProfileDetailByUuid(Long viewerId, String targetUserUuid);
 
 }

--- a/src/main/java/com/chat_server/userprofile/repository/impl/UserProfileRepositoryCustomImpl.java
+++ b/src/main/java/com/chat_server/userprofile/repository/impl/UserProfileRepositoryCustomImpl.java
@@ -1,24 +1,25 @@
 package com.chat_server.userprofile.repository.impl;
 
 import com.chat_server.user.entity.QUser;
-import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import com.chat_server.userprofile.enrtity.QUserProfile;
 import com.chat_server.userprofile.enrtity.UserProfile;
 import com.chat_server.userprofile.repository.UserProfileRepositoryCustom;
 import com.chat_server.userprofileImage.entity.QUserProfileImage;
 import com.querydsl.core.types.Projections;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.Optional;
 
 public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport implements UserProfileRepositoryCustom {
     private final QUserProfile qUserProfile = QUserProfile.userProfile;
     private final QUser qUser = QUser.user;
     private final QUserProfileImage qUserProfileImage = QUserProfileImage.userProfileImage;
+
     public UserProfileRepositoryCustomImpl() {
         super(UserProfile.class);
     }
-
 
     @Override
     public Optional<UserMyProfileSummaryResponse> findMyProfile(Long id) {
@@ -33,6 +34,7 @@ public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport i
                                 UserMyProfileSummaryResponse.class,
                                 qUser.uuid,
                                 qUser.nickname,
+                                qUser.friendCode,
                                 qUserProfile.stateMessage,
                                 qUserProfileImage.imageUrl
                         ))
@@ -41,26 +43,25 @@ public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport i
         );
     }
 
-
-    // 쿼리 관점으로 from 기준을 잡으면 될듯.
-    // user profile 무조건 존재한다고 가정 하면은. user profile 가능, 그렇지만 무조건 존재하지 않는다면은 user로 잡아야 함
-    // 그 이유는 user profile이 없는 사람이 있다면 프로필을 가지고 올 수 없기 때문
     @Override
     public Optional<UserMyProfileDetailResponse> findProfileDetail(Long id) {
-        return
-                 Optional.ofNullable(
-                         from(qUserProfile)
-                                 .leftJoin(qUserProfile).on(qUserProfile.user.eq(qUser))
-                                 .leftJoin(qUserProfileImage).on(qUserProfileImage.userProfile.eq(qUserProfile)
-                                         .and(qUserProfileImage.current.isTrue()))
-                                 .select(Projections.constructor(
-                                         UserMyProfileDetailResponse.class,
-                                         qUser.nickname,
-                                         qUserProfile.stateMessage,
-                                         qUserProfileImage.imageUrl
-                                 ))
-                                 .where(qUserProfile.user.id.eq(id))
-                                 .fetchOne()
-                 );
+        return Optional.ofNullable(
+                from(qUserProfile)
+                        .join(qUserProfile.user, qUser)
+                        .leftJoin(qUserProfileImage).on(
+                                qUserProfileImage.userProfile.eq(qUserProfile)
+                                        .and(qUserProfileImage.current.isTrue())
+                        )
+                        .select(Projections.constructor(
+                                UserMyProfileDetailResponse.class,
+                                qUser.uuid,
+                                qUser.nickname,
+                                qUser.friendCode,
+                                qUserProfile.stateMessage,
+                                qUserProfileImage.imageUrl
+                        ))
+                        .where(qUser.id.eq(id))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/com/chat_server/userprofile/repository/impl/UserProfileRepositoryCustomImpl.java
+++ b/src/main/java/com/chat_server/userprofile/repository/impl/UserProfileRepositoryCustomImpl.java
@@ -1,21 +1,26 @@
 package com.chat_server.userprofile.repository.impl;
 
+import com.chat_server.friend.entity.QFriend;
 import com.chat_server.user.entity.QUser;
-import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.user.enums.UserStatus;
+import com.chat_server.userprofile.dto.response.UserProfileDetailResponse;
 import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import com.chat_server.userprofile.enrtity.QUserProfile;
 import com.chat_server.userprofile.enrtity.UserProfile;
 import com.chat_server.userprofile.repository.UserProfileRepositoryCustom;
 import com.chat_server.userprofileImage.entity.QUserProfileImage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.Optional;
 
 public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport implements UserProfileRepositoryCustom {
+
     private final QUserProfile qUserProfile = QUserProfile.userProfile;
     private final QUser qUser = QUser.user;
     private final QUserProfileImage qUserProfileImage = QUserProfileImage.userProfileImage;
+    private final QFriend qFriend = QFriend.friend;
 
     public UserProfileRepositoryCustomImpl() {
         super(UserProfile.class);
@@ -38,13 +43,21 @@ public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport i
                                 qUserProfile.stateMessage,
                                 qUserProfileImage.imageUrl
                         ))
-                        .where(qUser.id.eq(id))
+                        .where(
+                                qUser.id.eq(id)
+                                        .and(qUser.status.eq(UserStatus.ACTIVE))
+                        )
                         .fetchOne()
         );
     }
 
+    /**
+     * 내 프로필 상세 조회
+     * - me = true
+     * - friend = false
+     */
     @Override
-    public Optional<UserMyProfileDetailResponse> findProfileDetail(Long id) {
+    public Optional<UserProfileDetailResponse> findProfileDetail(Long id) {
         return Optional.ofNullable(
                 from(qUserProfile)
                         .join(qUserProfile.user, qUser)
@@ -53,14 +66,58 @@ public class UserProfileRepositoryCustomImpl extends QuerydslRepositorySupport i
                                         .and(qUserProfileImage.current.isTrue())
                         )
                         .select(Projections.constructor(
-                                UserMyProfileDetailResponse.class,
+                                UserProfileDetailResponse.class,
                                 qUser.uuid,
                                 qUser.nickname,
                                 qUser.friendCode,
                                 qUserProfile.stateMessage,
-                                qUserProfileImage.imageUrl
+                                qUserProfileImage.imageUrl,
+                                Expressions.constant(false), // friend
+                                Expressions.constant(true)   // me
                         ))
-                        .where(qUser.id.eq(id))
+                        .where(
+                                qUser.id.eq(id)
+                                        .and(qUser.status.eq(UserStatus.ACTIVE))
+                        )
+                        .fetchOne()
+        );
+    }
+
+    /**
+     * uuid 기반 프로필 상세 조회
+     * - viewerId: 현재 로그인한 사용자 id
+     * - targetUserUuid: 조회 대상 사용자 uuid
+     */
+    @Override
+    public Optional<UserProfileDetailResponse> findProfileDetailByUuid(
+            Long viewerId,
+            String targetUserUuid
+    ) {
+        return Optional.ofNullable(
+                from(qUserProfile)
+                        .join(qUserProfile.user, qUser)
+                        .leftJoin(qUserProfileImage).on(
+                                qUserProfileImage.userProfile.eq(qUserProfile)
+                                        .and(qUserProfileImage.current.isTrue())
+                        )
+                        .leftJoin(qFriend).on(
+                                qFriend.user.id.eq(viewerId)
+                                        .and(qFriend.friendUser.eq(qUser))
+                        )
+                        .select(Projections.constructor(
+                                UserProfileDetailResponse.class,
+                                qUser.uuid,
+                                qUser.nickname,
+                                qUser.friendCode,
+                                qUserProfile.stateMessage,
+                                qUserProfileImage.imageUrl,
+                                qFriend.id.isNotNull(), // friend
+                                qUser.id.eq(viewerId)   // me
+                        ))
+                        .where(
+                                qUser.uuid.eq(targetUserUuid)
+                                        .and(qUser.status.eq(UserStatus.ACTIVE))
+                        )
                         .fetchOne()
         );
     }

--- a/src/main/java/com/chat_server/userprofile/service/UserProfileService.java
+++ b/src/main/java/com/chat_server/userprofile/service/UserProfileService.java
@@ -1,7 +1,6 @@
 package com.chat_server.userprofile.service;
 
-import com.chat_server.userprofile.dto.request.UserProfileUpdateRequest;
-import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.userprofile.dto.response.UserProfileDetailResponse;
 import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 
 public interface UserProfileService {
@@ -17,9 +16,12 @@ public interface UserProfileService {
      * @param userId 유저 아이디
      * @return 상세 정보 DTO
      */
-    UserMyProfileDetailResponse getMyProfileDetail(Long userId);
-    UserMyProfileDetailResponse getMyProfileDetail(String userId);
+    UserProfileDetailResponse getMyProfileDetail(Long userId);
+
     void updateStateMessage(Long userId, String message);
 
     void createUserProfile(String userUuid);
+
+    UserProfileDetailResponse getProfileDetailByUuid(Long viewerId, String targetUserUuid);
+
 }

--- a/src/main/java/com/chat_server/userprofile/service/impl/UserProfileServiceImpl.java
+++ b/src/main/java/com/chat_server/userprofile/service/impl/UserProfileServiceImpl.java
@@ -3,8 +3,7 @@ package com.chat_server.userprofile.service.impl;
 import com.chat_server.user.entity.User;
 import com.chat_server.user.exception.UserNotFoundException;
 import com.chat_server.user.repository.UserRepository;
-import com.chat_server.userprofile.dto.request.UserProfileUpdateRequest;
-import com.chat_server.userprofile.dto.response.UserMyProfileDetailResponse;
+import com.chat_server.userprofile.dto.response.UserProfileDetailResponse;
 import com.chat_server.userprofile.dto.response.UserMyProfileSummaryResponse;
 import com.chat_server.userprofile.enrtity.UserProfile;
 import com.chat_server.userprofile.repository.UserProfileRepository;
@@ -19,56 +18,53 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class UserProfileServiceImpl implements UserProfileService {
+
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
 
-
-    // todo 본인의 프로필 상세 내용을 가지고 옴. 프로필 사진을 클릭 한 뒤 나오는 데이터 들
     @Override
     @Transactional(readOnly = true)
     public UserMyProfileSummaryResponse getMyProfileSummary(Long userId) {
-        log.info("getMyProfile");
-        log.info("userId: " + userId);
-        return userProfileRepository.findMyProfile(userId).orElseThrow(()->new UserNotFoundException("유저 프로필을 찾을 수 없음"));
+        log.info("getMyProfileSummary userId={}", userId);
+
+        return userProfileRepository.findMyProfile(userId)
+                .orElseThrow(() -> new UserNotFoundException("유저 프로필을 찾을 수 없습니다."));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public UserMyProfileDetailResponse getMyProfileDetail(Long userId) {
-        log.info("getMyProfileDetail");
-        UserMyProfileDetailResponse response = getProfileDetail(userId);
-        log.info("response: {}", response.toString());
-        return response;
+    public UserProfileDetailResponse getMyProfileDetail(Long userId) {
+        log.info("getMyProfileDetail userId={}", userId);
+
+        return userProfileRepository.findProfileDetail(userId)
+                .orElseThrow(() -> new UserNotFoundException("유저 프로필을 찾을 수 없습니다."));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public UserMyProfileDetailResponse getMyProfileDetail(String userId) {
-        // 실제 친구가 있는지 확인
-        log.info("getMyProfileDetail");
-        Long id = userRepository.getUserIdByUserUuid(userId).orElseThrow(UserNotFoundException::new);
-        log.info("id: {}", id);
-        UserMyProfileDetailResponse response = getProfileDetail(id);
-        log.info("response: {}", response.toString());
+    public UserProfileDetailResponse getProfileDetailByUuid(Long viewerId, String targetUserUuid) {
+        log.info("getProfileDetailByUuid viewerId={}, targetUserUuid={}", viewerId, targetUserUuid);
 
-        return response;
+        return userProfileRepository.findProfileDetailByUuid(viewerId, targetUserUuid)
+                .orElseThrow(() -> new UserNotFoundException("유저 프로필을 찾을 수 없습니다."));
     }
 
     @Override
     public void updateStateMessage(Long userId, String message) {
-        log.info("updateUserProfile");
+        log.info("updateStateMessage userId={}", userId);
 
         UserProfile userProfile = userProfileRepository.findByUser_Id(userId)
-            .orElseThrow(UserNotFoundException::new);
+                .orElseThrow(() -> new UserNotFoundException("유저 프로필을 찾을 수 없습니다."));
 
         userProfile.update(message);
     }
 
     @Override
     public void createUserProfile(String userUuid) {
-        log.debug("Creating user profile url");
+        log.debug("Creating user profile userUuid={}", userUuid);
+
         User user = userRepository.findByUuid(userUuid)
-                .orElseThrow(UserNotFoundException::new);
+                .orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다."));
 
         UserProfile userProfile = UserProfile.builder()
                 .stateMessage("")
@@ -77,14 +73,6 @@ public class UserProfileServiceImpl implements UserProfileService {
 
         userProfileRepository.save(userProfile);
 
-        log.debug("Creating user profile url end");
+        log.debug("Creating user profile end");
     }
-
-    private UserMyProfileDetailResponse getProfileDetail(Long userId) {
-        log.info("private method getProfileDetail");
-        return userProfileRepository.findProfileDetail(userId)
-                .orElse(new UserMyProfileDetailResponse("","","","",""));
-
-    }
-
 }

--- a/src/main/java/com/chat_server/userprofile/service/impl/UserProfileServiceImpl.java
+++ b/src/main/java/com/chat_server/userprofile/service/impl/UserProfileServiceImpl.java
@@ -83,7 +83,7 @@ public class UserProfileServiceImpl implements UserProfileService {
     private UserMyProfileDetailResponse getProfileDetail(Long userId) {
         log.info("private method getProfileDetail");
         return userProfileRepository.findProfileDetail(userId)
-                .orElse(new UserMyProfileDetailResponse("","",""));
+                .orElse(new UserMyProfileDetailResponse("","","","",""));
 
     }
 

--- a/src/main/resources/script/ddl.sql
+++ b/src/main/resources/script/ddl.sql
@@ -89,6 +89,7 @@ create table if not exists user
     age             int                                   null,
     name            varchar(30)                           not null,
     nickname        varchar(30)                           not null,
+    friend_code     varchar(20)                           not null,
     uuid            varchar(36)                           not null,
     status          varchar(20) default 'ACTIVE'          not null,
     created_at      datetime    default CURRENT_TIMESTAMP not null,
@@ -98,6 +99,8 @@ create table if not exists user
         unique (input_id),
     constraint uk_user_uuid
         unique (uuid),
+    constraint uk_user_friend_code
+        unique (friend_code),
     constraint fk_user_gender
         foreign key (gender_id) references gender (id),
     constraint fk_user_login_type


### PR DESCRIPTION
## 작업 개요

OAuth 로그인 도입 이후 기존 `inputId` 기반 친구 검색 방식에 한계가 발생했습니다.

일반 회원가입 사용자는 직접 입력한 `inputId`로 검색할 수 있지만, OAuth 사용자는 내부적으로 생성된 `inputId`를 사용하기 때문에 다른 사용자가 해당 값을 알 수 없었습니다.

이를 해결하기 위해 사용자에게 노출 가능한 `friendCode`를 도입하고, 친구 검색 기준을 `inputId` 중심에서 `friendCode` 중심으로 개선했습니다.

또한 프로필 상세 응답 구조를 정리하여 내 프로필과 다른 사용자의 프로필을 동일한 DTO로 응답할 수 있도록 개선하고, 친구 등록 시 자기 자신 추가 및 중복 추가를 방지하도록 검증 로직을 추가했습니다.

---

## 주요 변경 사항

### 1. User friendCode 추가

사용자에게 노출 가능한 친구 검색용 식별자인 `friendCode`를 추가했습니다.

추가된 내용은 다음과 같습니다.

- `User.friendCode` 필드 추가
- `friend_code` 컬럼 unique 제약 추가
- `UserRepository.existsByFriendCode()` 추가
- 일반 회원가입 시 friendCode 자동 생성

friendCode는 다음 형식으로 생성됩니다.

```text
CTK-XXXXXXXX
```

생성 시 혼동되기 쉬운 문자를 제외한 문자열을 사용하고, 중복 방지를 위해 최대 재시도 후 고유한 코드를 생성하도록 처리했습니다.

---

### 2. 친구코드 기반 사용자 검색 개선

기존 검색 요청은 `userId` 기준이었으나, 신규 구조에서는 `keyword`를 기준으로 검색하도록 변경했습니다.

변경된 요청 DTO:

```java
public record SearchUserRequest(
        @JsonAlias({"userId", "friendCode"})
        @NotBlank(message = "검색어는 필수입니다.")
        @Size(min = 1, max = 30, message = "검색어는 1자 이상 30자 이하로 입력해주세요.")
        String keyword
) {
}
```

기존 프론트 호환을 위해 `userId`, `friendCode`도 alias로 받을 수 있도록 했습니다.

---

### 3. 검색어 정규화 처리 추가

친구코드 검색 시 사용자가 하이픈이나 공백을 다르게 입력해도 검색할 수 있도록 정규화 로직을 추가했습니다.

예:

```text
CTK-A8F3K92Q
CTKA8F3K92Q
ctk-a8f3k92q
```

위 입력을 모두 동일한 친구코드 형태로 변환하여 검색합니다.

---

### 4. 검색 응답 정보 확장

검색 결과에서 프론트가 사용자 상태를 판단할 수 있도록 응답 정보를 확장했습니다.

변경된 응답 DTO:

```java
public record SearchUserResponse(
        String uuid,
        String name,
        String friendCode,
        String profileUrl,
        boolean isFriend,
        boolean isMe
) {
}
```

추가된 필드:

- `friendCode`: 사용자에게 표시할 친구코드
- `isFriend`: 이미 친구인지 여부
- `isMe`: 검색 결과가 본인인지 여부

이를 통해 프론트에서 다음과 같은 UI 처리가 가능해졌습니다.

```text
본인 검색 → 본인 표시
이미 친구 → 추가 버튼 비활성화
친구 아님 → 친구 추가 가능
```

---

### 5. UserRepositoryCustom 검색 쿼리 개선

기존 `inputId` 기반 검색에서 `friendCode` 기반 검색으로 변경하고, 임시 호환을 위해 `inputId` 검색도 함께 허용했습니다.

검색 조건:

```text
user.friendCode = keyword
OR user.inputId = keyword
```

또한 검색 결과에 현재 사용자의 친구 여부와 본인 여부를 함께 계산하도록 Querydsl projection을 수정했습니다.

---

### 6. 친구 등록 검증 강화

친구 등록 시 다음 예외 상황을 검증하도록 개선했습니다.

- 자기 자신을 친구로 추가하는 경우
- 이미 친구인 사용자를 다시 추가하는 경우
- 존재하지 않는 사용자 uuid를 요청하는 경우

추가된 Repository 메서드:

```java
boolean existsByUser_IdAndFriendUser_Id(Long userId, Long friendUserId);
```

검증 흐름:

```text
친구 등록 요청
→ 요청 대상 uuid로 User 조회
→ 자기 자신 여부 확인
→ 기존 친구 여부 확인
→ Friend 저장
```

---

### 7. 프로필 상세 응답 DTO 정리

기존 `UserMyProfileDetailResponse`는 이름상 내 프로필 전용처럼 보였지만, 실제로는 다른 사람의 프로필 조회에도 사용되고 있어 정합성이 떨어졌습니다.

이를 개선하기 위해 공통 프로필 상세 응답 DTO인 `UserProfileDetailResponse`를 추가하고, 내 프로필과 다른 사용자 프로필 모두 동일한 응답 구조를 사용하도록 변경했습니다.

신규 DTO:

```java
public record UserProfileDetailResponse(
        String uuid,
        String nickName,
        String friendCode,
        String message,
        String profileUrl,
        boolean friend,
        boolean me
) {
}
```

---

### 8. 내 프로필 / 상대 프로필 조회 API 정리

기존 프로필 조회 API의 역할을 명확히 분리했습니다.

내 프로필 요약:

```http
GET /api/v1/users/me/profile/summary
```

내 프로필 상세:

```http
GET /api/v1/users/me/profile/detail
```

uuid 기반 프로필 상세:

```http
GET /api/v1/users/profile/{userUuid}
```

`/profile/{userUuid}` API는 친구 목록, 검색 결과, 채팅방 메시지 프로필 클릭 등에서 공통으로 사용할 수 있도록 설계했습니다.

---

### 9. 프로필 조회 시 friend/me 상태 포함

프로필 상세 조회 시 현재 로그인한 사용자 기준으로 다음 값을 계산하도록 개선했습니다.

```text
friend = 현재 로그인 사용자의 친구 여부
me = 조회 대상이 현재 로그인 사용자 본인인지 여부
```

내 프로필 상세 조회에서는 다음과 같이 고정됩니다.

```text
friend = false
me = true
```

상대 프로필 상세 조회에서는 Querydsl을 통해 친구 여부와 본인 여부를 계산합니다.

---

### 10. 프로필 요약 응답에 friendCode 추가

사이드바의 내 프로필 정보에서도 친구코드를 사용할 수 있도록 `UserMyProfileSummaryResponse`에 `friendCode`를 추가했습니다.

변경된 응답:

```java
public record UserMyProfileSummaryResponse(
        String uuid,
        String nickName,
        String friendCode,
        String message,
        String profileUrl
) {
}
```

---

### 11. 불필요한 로그 및 주석 정리

친구 목록 조회와 친구 등록 과정에 남아 있던 디버깅성 로그를 정리했습니다.

정리된 내용:

- 불필요한 단계별 `log.info()` 제거
- 오래된 주석 코드 제거
- Controller 응답 생성 흐름 정리
- 프로필 관련 메서드명 정리

---

## 변경된 주요 파일

- `FriendRepository`
- `FriendServiceImpl`
- `SearchController`
- `SearchUserRequest`
- `SearchUserResponse`
- `SearchService`
- `SearchServiceImpl`
- `User`
- `UserRepository`
- `UserRepositoryCustom`
- `UserRepositoryCustomImpl`
- `UserServiceImpl`
- `UserProfileController`
- `UserMyProfileSummaryResponse`
- `UserProfileDetailResponse`
- `UserProfileRepository`
- `UserProfileRepositoryCustom`
- `UserProfileRepositoryCustomImpl`
- `UserProfileService`
- `UserProfileServiceImpl`

---

## 검증 내용

### 친구코드 생성

- 일반 회원가입 시 `friendCode`가 자동 생성되는지 확인
- 생성된 `friendCode`가 `CTK-XXXXXXXX` 형식인지 확인
- `friend_code` unique 제약이 적용되는지 확인
- 중복 friendCode 생성 시 재시도 로직이 동작하는지 확인

### 친구 검색

- `friendCode`로 사용자 검색이 되는지 확인
- 하이픈이 없는 친구코드 입력도 정규화되어 검색되는지 확인
- 기존 `userId`, `friendCode` 요청 필드도 alias로 처리되는지 확인
- 검색 결과에 `friendCode`, `isFriend`, `isMe`가 포함되는지 확인
- 존재하지 않는 검색어 요청 시 예외가 발생하는지 확인

### 친구 등록

- 정상적으로 친구 추가가 되는지 확인
- 자기 자신을 친구로 추가할 수 없는지 확인
- 이미 친구인 사용자를 중복 추가할 수 없는지 확인
- 존재하지 않는 uuid로 친구 추가 시 예외가 발생하는지 확인

### 프로필 조회

- 내 프로필 요약 응답에 `friendCode`가 포함되는지 확인
- 내 프로필 상세 응답에 `friend=false`, `me=true`가 내려오는지 확인
- uuid 기반 상대 프로필 조회가 정상 동작하는지 확인
- 상대 프로필 조회 시 친구 여부가 `friend` 값에 반영되는지 확인
- 본인 uuid를 `/profile/{userUuid}`로 조회할 경우 `me=true`가 계산되는지 확인

---

## 기대 효과

- OAuth 사용자도 친구코드 기반으로 검색할 수 있습니다.
- 내부 식별자인 `uuid/inputId`와 사용자 노출 식별자인 `friendCode`를 분리할 수 있습니다.
- 친구 검색, 친구 추가, 프로필 조회가 로그인 방식과 무관하게 동작합니다.
- 프론트에서 본인/친구/비친구 상태에 따라 UI를 명확히 분기할 수 있습니다.
- 프로필 상세 응답 DTO를 공통화하여 내 프로필과 상대 프로필 조회 구조의 정합성이 개선되었습니다.
- 친구 등록 시 자기 자신 추가와 중복 추가를 방지하여 데이터 정합성이 개선되었습니다.

---

## 체크리스트

- [x] User friendCode 필드 추가
- [x] friendCode unique 제약 추가
- [x] 일반 회원가입 시 friendCode 자동 생성
- [x] friendCode 기반 사용자 검색 추가
- [x] 검색어 정규화 처리 추가
- [x] 기존 userId/friendCode 요청 필드 alias 처리
- [x] 검색 응답에 friendCode 추가
- [x] 검색 응답에 isFriend/isMe 추가
- [x] 친구 등록 시 자기 자신 추가 방지
- [x] 친구 등록 시 중복 추가 방지
- [x] 내 프로필 요약 응답에 friendCode 추가
- [x] UserProfileDetailResponse 추가
- [x] 내 프로필 상세 / 상대 프로필 상세 응답 구조 통일
- [x] uuid 기반 프로필 상세 조회 API 추가
- [x] 프로필 조회 시 friend/me 상태 계산
- [x] 불필요한 디버깅 로그 정리

---
